### PR TITLE
Fixed bug that extracting multiple tracks at the same time can fails

### DIFF
--- a/src/mp4box.js
+++ b/src/mp4box.js
@@ -225,7 +225,7 @@ MP4Box.prototype.processSamples = function() {
 					trak.nextSample++;
 					extractTrak.samples.push(sample);
 				} else {
-					return;
+					break;
 				}
 				if (trak.nextSample % extractTrak.nb_samples === 0 || trak.nextSample >= trak.samples.length) {
 					Log.debug("MP4Box", "Sending samples on track #"+extractTrak.id+" for sample "+trak.nextSample); 


### PR DESCRIPTION
If the first track doesn't have enough data, the function returns and all other tracks cannot be processed.
It should be break instead.