### PR TITLE
Provide the segment time with the call to onSegment()

### DIFF
--- a/src/mp4box.js
+++ b/src/mp4box.js
@@ -156,6 +156,7 @@ MP4Box.prototype.createFragment = function(input, track_id, sampleNumber, stream
 MP4Box.prototype.processSamples = function() {
 	var i;
 	var trak;
+	var sample;
 	if (!this.sampleProcessingStarted) return;
 
 	/* For each track marked for fragmentation, 
@@ -184,7 +185,7 @@ MP4Box.prototype.processSamples = function() {
 					Log.info("MP4Box", "Sample data size in memory: "+this.inputIsoFile.getAllocatedSampleDataSize()); 			
 					if (this.onSegment) {
 						/* get the time for this segment */
-						var sample = trak.nextSample < trak.samples.length && trak.samples[trak.nextSample];
+						sample = trak.nextSample < trak.samples.length && trak.samples[trak.nextSample];
 						var time = (sample.dts + sample.duration) / sample.timescale;
 						this.onSegment(fragTrak.id, fragTrak.user, fragTrak.segmentStream.buffer, trak.nextSample, time);
 					}
@@ -207,7 +208,7 @@ MP4Box.prototype.processSamples = function() {
 			trak = extractTrak.trak;
 			while (trak.nextSample < trak.samples.length && this.sampleProcessingStarted) {				
 				Log.debug("MP4Box", "Exporting on track #"+extractTrak.id +" sample #"+trak.nextSample);
-				var sample = this.inputIsoFile.getSample(trak, trak.nextSample);
+				sample = this.inputIsoFile.getSample(trak, trak.nextSample);
 				if (sample) {
 					trak.nextSample++;
 					extractTrak.samples.push(sample);

--- a/src/mp4box.js
+++ b/src/mp4box.js
@@ -183,7 +183,10 @@ MP4Box.prototype.processSamples = function() {
 					Log.info("MP4Box", "Sending fragmented data on track #"+fragTrak.id+" for samples ["+Math.max(0,trak.nextSample-fragTrak.nb_samples)+","+(trak.nextSample-1)+"]"); 
 					Log.info("MP4Box", "Sample data size in memory: "+this.inputIsoFile.getAllocatedSampleDataSize()); 			
 					if (this.onSegment) {
-						this.onSegment(fragTrak.id, fragTrak.user, fragTrak.segmentStream.buffer, trak.nextSample);
+						/* get the time for this segment */
+						var sample = trak.nextSample < trak.samples.length && trak.samples[trak.nextSample];
+						var time = (sample.dts + sample.duration) / sample.timescale;
+						this.onSegment(fragTrak.id, fragTrak.user, fragTrak.segmentStream.buffer, trak.nextSample, time);
 					}
 					/* force the creation of a new buffer */
 					fragTrak.segmentStream = null;


### PR DESCRIPTION
This is an attempt to deal with this exception:

> QuotaExceededError: Failed to execute 'appendBuffer' on 'SourceBuffer': The SourceBuffer is full, and cannot free space to append additional buffers.

So, my idea is that if we've enough segments, we can throttle the download until `video.currentTime` is near the last segment time.
