### PR TITLE
When adding HTML5 tracks don't do it if the trackkind is still empty.…

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -311,7 +311,7 @@ function addBuffer(video, mp4track) {
 				break;
 			}
 		}
-		if (!foundTextTrack) {
+		if ((!foundTextTrack) && (html5TrackKind !== "")) {
 			var texttrack = video.addTextTrack(html5TrackKind, mp4track.name, mp4track.language);
 			texttrack.id = track_id;
 			texttrack.mode = "showing";


### PR DESCRIPTION
…  Solves crash on presence of tmcd track.  not sure if there is ever a valid time to add a track with the 'TrackKind' an empty string?

I have a 375k test file which contains a tmcd track; or you can make one with:

ffmpeg -f lavfi -i sine=frequency=1000:beep_factor=2:r=48000:duration=10.0 -f lavfi -i testsrc=duration=10.0:rate=25 -vcodec libx264 -profile:v high -pix_fmt yuv420p -preset slow -b:v 500k -maxrate 500k -bufsize 1000k -timecode 10:00:00:00 -r 25 -vf "drawtext=fontfile=/Windows/Fonts/cour.ttf: text='TC: ': timecode='10:00:00:00': r=25: fontsize=20: x=20: y=20: fontcolor=white: box=1: boxcolor=0x00000099" -y out\25-10sec.mp4

nice work on the mp4 parsing.
