### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On this page, you'll find documentation on how to [build MP4box.js](#build), [us
 API
 ===
 
-###Getting Information###
+### Getting Information ###
 Similar to `MP4Box -info file.mp4`, MP4Box.js can provide general information about the file (duration, number and types of tracks ...). For that, create an MP4Box object, set the `onReady` callback and provide data in the form of ArrayBuffer objects. MP4Box.js supports progressive parsing. You can provide small buffers at a time, the callback will be called when the 'moov' box is parsed.
 
 ```javascript
@@ -36,7 +36,7 @@ mp4box.appendBuffer(data);
 mp4box.flush();
 ```
 
-####onMoovStart()####
+#### onMoovStart() ####
 The `onMoovStart` callback is called when the 'moov' box is starting to be parsed. Depending on the download speed, it may take a while to download the whole 'moov' box. The end of parsing is signaled by the `onReady` callback.
 
 ```javascript
@@ -45,7 +45,7 @@ mp4box.onMoovStart = function () {
 }
 ```
 
-####onReady(info)####
+#### onReady(info) ####
 The `onReady` callback is called when the the 'moov' box has been parsed, i.e. when the metadata about the file is parsed. 
 
 ```javascript
@@ -148,7 +148,7 @@ Audio-specific information object:
 - **channel_count**: Number, number of channels as indicated in the media header,
 - **sample_size**: Number, size in bits of an uncompressed audio sample as indicated in the media header,
 
-####onError(e)####
+#### onError(e) ####
 Indicates that an error has occured during the processing. `e` is a String.
 ```javascript
 mp4box.onError = function (e) {
@@ -156,7 +156,7 @@ mp4box.onError = function (e) {
 }
 ```
 
-####appendBuffer(data)####
+#### appendBuffer(data) ####
 Provides an ArrayBuffer to parse from. The ArrayBuffer must have a `fileStart` (Number) property indicating the 0-based position of first byte of the ArrayBuffer in the original file. Returns the offset (in the original file) that is expected to be the `fileStart` value of the next buffer. This is particularly useful when the moov box is not at the beginning of the file.
 ```javascript
 var ab = getArrayBuffer();
@@ -164,16 +164,16 @@ ab.fileStart = 0;
 var nextBufferStart = mp4box.appendBuffer(ab);
 ```
 
-####start()####
+#### start() ####
 Indicates that sample processing can start (segmentation or extraction). Sample data already received will be processed and new buffer append operation will trigger sample processing as well.
 
-####stop()####
+#### stop() ####
 Indicates that sample processing is stopped. Buffer append operations will not trigger calls to onSamples or onSegment.
 
-####flush()####
+#### flush() ####
 Indicates that no more data will be received and that all remaining samples should be flushed in the segmentation or extraction process.
 
-###Segmentation###
+### Segmentation ###
 
 ```javascript
 var mp4box = new MP4Box();
@@ -187,7 +187,7 @@ mp4box.onReady = function(info) {
 };
 ```
 
-####setSegmentOptions(track_id, user, options)####
+#### setSegmentOptions(track_id, user, options) ####
 Indicates that the track with the given `track_id` should be segmented, with the given options. When segments are ready, the callback [onSegment](#onsegmentid_user_buffer) is called with the `user` parameter. The `options` argument is an object with the following properties:
 - **nbSamples**: Number, representing the number of frames per segment, i.e. the time between 2 callbacks to onSegment. If not enough data is received to form a segment, received samples are kept. If not provided, the default is 1000.
 - **rapAlignement**: boolean, indicating if segments should start with a RAP. If not provided, the default is true.
@@ -196,13 +196,13 @@ Indicates that the track with the given `track_id` should be segmented, with the
 mp4box.setSegmentOptions(1, sb, { nbSamples: 1000 });
 ```
  
-####unsetSegmentOptions(track_id)####
+#### unsetSegmentOptions(track_id) ####
 Indicates that the track with the given `track_id` should not be segmented.
 ```javascript
 mp4box.unsetSegmentOptions(1);
 ```
 
-####onSegment(id, user, buffer)####
+#### onSegment(id, user, buffer) ####
 Callback called when a segment is ready, according to the options passed in [setSegmentOptions](##setsegmentoptionstrack_id-user-options). `user` is the caller of the segmentation, for this track, and `buffer` is an ArrayBuffer containing the Movie Fragments for this segment.
 
 ```javascript
@@ -211,7 +211,7 @@ mp4box.onSegment = function (id, user, buffer) {
 }
 ```
 
-####initializeSegmentation()####
+#### initializeSegmentation() ####
 Indicates that the application is ready to receive segments. Returns an array of objects containing the following properties:
 - **id**: Number, the track id 
 - **user**: Object, the caller of the segmentation for this track, as given in [setSegmentOptions](##setsegmentoptionstrack_id-user-options)
@@ -232,7 +232,7 @@ Indicates that the application is ready to receive segments. Returns an array of
 ]
 ```
 
-###Extraction###
+### Extraction ###
 It is possible to extract the samples of a track, in a similar manner to the segmentation process.
 ```javascript
 var mp4box = new MP4Box();
@@ -247,7 +247,7 @@ mp4box.onReady = function(info) {
 };
 ```
 
-####setExtractionOptions(track_id, user, options)####
+#### setExtractionOptions(track_id, user, options) ####
 Indicates that the track with the given `track_id` for which samples should be extracted, with the given options. When samples are ready, the callback [onSamples](#onsamplesid-user-samples) is called with the `user` parameter. The `options` argument is an object with the following properties:
 - **nbSamples**: Number, representing the number of samples per callback callt. If not enough data is received to extract the number of samples, the samples received so far are kept. If not provided, the default is 1000.
 - **rapAlignement**: boolean, indicating if sample arrays should start with a RAP. If not provided, the default is true.
@@ -256,13 +256,13 @@ Indicates that the track with the given `track_id` for which samples should be e
 mp4box.setExtractionOptions(1, texttrack, { nbSamples: 1000 });
 ```
  
-####unsetExtractionOptions(track_id)####
+#### unsetExtractionOptions(track_id) ####
 Indicates that the samples for the track with the given `track_id` should not be extracted.
 ```javascript
 mp4box.unsetExtractionOptions(1);
 ```
 
-####onSamples(id, user, samples)####
+#### onSamples(id, user, samples) ####
 Callback called when a set of samples is ready, according to the options passed in [setExtractionOptions](#setextractionoptionstrack_id-user-options). `user` is the caller of the segmentation, for this track, and `samples` is an Array of samples.
 
 ```javascript
@@ -286,12 +286,12 @@ Each sample has the following structure:
 }
 ```
 
-####seek(time, useRap)####
+#### seek(time, useRap) ####
 Indicates that the next samples to process (for extraction or segmentation) start at the given time (Number, in seconds) or at the time of the previous Random Access Point (if useRap is true, default is false). Returns the offset in the file of the next bytes to be provided via [appendBuffer](#appendbufferdata) .
 ```javascript
 mp4box.seek(10, true);
 ```
-####releaseUsedSamples(id, sampleNumber)####
+#### releaseUsedSamples(id, sampleNumber) ####
 Releases the memory allocated for sample data for the given track id, up to (but excluding) the given sample number.
 ```
 mp4box.releaseUsedSamples(1, 250);


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
