### PR TITLE
Add support for parsing FLAC in ISOBMFF

### DIFF
--- a/src/box.js
+++ b/src/box.js
@@ -38,7 +38,8 @@ var BoxParser = {
 				  "kind", "elng", 
 				  "ipma", "pixi", "ispe",
 				  "tenc",
-				  "vpcC"
+				  "vpcC",
+				  "dfLa"
 				  /* missing "stsd", "iref", : special case full box and container */
 				],
 	containerBoxCodes : [ 
@@ -73,7 +74,7 @@ var BoxParser = {
 	sampleEntryCodes : [ 
 		/* 4CC as registered on http://mp4ra.org/codecs.html */
 		{ prefix: "Visual", types: [ "mp4v", "avc1", "avc2", "avc3", "avc4", "avcp", "drac", "encv", "mjp2", "mvc1", "mvc2", "resv", "s263", "svc1", "vc-1", "hvc1", "hev1"  ] },
-		{ prefix: "Audio", 	types: [ "mp4a", "ac-3", "alac", "dra1", "dtsc", "dtse", ,"dtsh", "dtsl", "ec-3", "enca", "g719", "g726", "m4ae", "mlpa",  "raw ", "samr", "sawb", "sawp", "sevc", "sqcp", "ssmv", "twos", ".mp3" ] },
+		{ prefix: "Audio", 	types: [ "mp4a", "ac-3", "alac", "dra1", "dtsc", "dtse", ,"dtsh", "dtsl", "ec-3", "enca", "g719", "g726", "m4ae", "mlpa",  "raw ", "samr", "sawb", "sawp", "sevc", "sqcp", "ssmv", "twos", ".mp3", "fLaC" ] },
 		{ prefix: "Hint", 	types: [ "fdp ", "m2ts", "pm2t", "prtp", "rm2t", "rrtp", "rsrp", "rtp ", "sm2t", "srtp" ] },
 		{ prefix: "Metadata", types: [ "metx", "mett", "urim" ] },
 		{ prefix: "Subtitle", types: [ "stpp", "wvtt", "sbtt", "tx3g", "stxt" ] },

--- a/src/parsing/dfLa.js
+++ b/src/parsing/dfLa.js
@@ -1,0 +1,54 @@
+BoxParser.dfLaBox.prototype.parse = function(stream) {
+    var BLOCKTYPE_MASK = 0x7F;
+    var LASTMETADATABLOCKFLAG_MASK = 0x80;
+    
+    var boxesFound = [];
+    var knownBlockTypes = [
+        "STREAMINFO",
+        "PADDING",
+        "APPLICATION",
+        "SEEKTABLE",
+        "VORBIS_COMMENT",
+        "CUESHEET",
+        "PICTURE",
+        "RESERVED"
+    ];
+
+    // dfLa is a FullBox
+    this.parseFullHeader(stream);
+
+    // for (i=0; ; i++) { // to end of box
+    do {
+        var flagAndType = stream.readUint8();
+
+        var type = Math.min(
+            (flagAndType & BLOCKTYPE_MASK),
+            (knownBlockTypes.length - 1)
+        );
+
+        // if this is a STREAMINFO block, read the true samplerate since this
+        // can be different to the AudioSampleEntry samplerate.
+        if (!(type)) {
+            // read past all the other stuff
+            stream.readUint8Array(13);
+
+            // extract samplerate
+            this.samplerate = (stream.readUint32() >> 12);
+
+            // read to end of STREAMINFO
+            stream.readUint8Array(20);
+        } else {
+            // not interested in other block types so just discard length bytes
+            stream.readUint8Array(stream.readUint24());
+        }
+
+        boxesFound.push(knownBlockTypes[type]);
+
+        if (!!(flagAndType & LASTMETADATABLOCKFLAG_MASK)) {
+            break;
+        }
+    } while (true);
+
+    this.numMetadataBlocks =
+        boxesFound.length + " (" + boxesFound.join(", ") + ")";
+};

--- a/test/sample-urls.js
+++ b/test/sample-urls.js
@@ -29,6 +29,7 @@ var sampleUrls = [
 			{ url: "http://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-aaclc_low.mp4", desc: "DASH onDemand audio (fragmented, AAC Low)"},
 			{ url: "http://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-h264bl_full.mp4", desc: "DASH onDemand video (fragmented, H.264/AVC Baseline Full HD)"},
 			{ url: "http://download.tsi.telecom-paristech.fr/gpac/DASH_CONFORMANCE/TelecomParisTech/mp4-onDemand/mp4-onDemand-h264bl_low.mp4", desc: "DASH onDemand video (fragmented, H.264/AVC Baseline Low Resolution)"},
+			{ url: "https://storage.googleapis.com/media-session/flac.mp4", desc: "FLAC in ISO-BMFF"}
 		]
 	},
 	{ 


### PR DESCRIPTION
Adds basic support for parsing fLaC sample entry as requested in https://github.com/gpac/mp4box.js/issues/128, and as defined in https://github.com/xiph/flac/blob/master/doc/isoflac.txt.

The dfLa box is read and the samplerate extracted from the STREAMINFO block, if present. All other fields in STREAMINFO are ignored. Non-STREAMINFO blocks are not parsed, although the total number of blocks and their types presence is noted. 