### PR TITLE
Add grunt-cli to devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ before_install:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
 - sleep 3 # give xvfb some time to start
-before_script:
-  - 'npm install -g grunt-cli'
-  - 'npm install grunt'
-  - 'npm install karma'
-  - 'npm install grunt-karma'
-  - 'npm install karma-phantomjs-launcher'
 deploy:
   - provider: releases
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ sudo: false
 node_js:
 - '6.0.0'
 before_install:
-- echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 - "export CHROME_BIN=chromium-browser"
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
 - sleep 3 # give xvfb some time to start
+before_deploy:
+- echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 deploy:
   - provider: releases
     api_key:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,14 @@ module.exports = function(config) {
         frameworks: ['qunit'],
 
 
+        // client configuration
+        client: {
+          qunit: {
+            testTimeout: 5000
+          }
+        },
+
+
         // list of files / patterns to load in the browser
         files: [
           '../src/log.js',                       // logging system

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "blanket": "^1.2.3",
     "grunt": "^0.4.5",
     "grunt-bump": "^0.3.1",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-qunit": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-chrome-launcher": "^0.1.12",
     "karma-coverage": "^0.5.5",
     "karma-firefox-launcher": "^0.1.6",
+    "karma-phantomjs-launcher": "^1.0.4",
     "karma-qunit": "^0.1.4",
     "qunitjs": "^1.23.0"
   },


### PR DESCRIPTION
This makes it possible to build mp4box without installing global
dependencies:

    npm install
    ./node_modules/.bin/grunt

EDIT: I merged #149 into this to demonstrate that the tests still pass.