### PR TITLE
Add `.log` method to Log object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 node_js:
 - '6.0.0'
 before_install:
-- echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 - "export CHROME_BIN=chromium-browser"
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
@@ -14,6 +13,8 @@ before_script:
   - 'npm install karma'
   - 'npm install grunt-karma'
   - 'npm install karma-phantomjs-launcher'
+before_deploy:
+- echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 deploy:
   - provider: releases
     api_key:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,14 @@ module.exports = function(config) {
         frameworks: ['qunit'],
 
 
+        // client configuration
+        client: {
+          qunit: {
+            testTimeout: 5000
+          }
+        },
+
+
         // list of files / patterns to load in the browser
         files: [
           '../src/log.js',                       // logging system

--- a/src/log.js
+++ b/src/log.js
@@ -25,6 +25,9 @@ var Log = (function (){
 					console.debug("["+Log.getDurationString(new Date()-start,1000)+"]","["+module+"]",msg);
 				}
 			},
+			log : function(module, msg) {
+				this.debug(module.msg)
+			},
 			info : function(module, msg) {
 				if (LOG_LEVEL_INFO >= log_level) {
 					console.info("["+Log.getDurationString(new Date()-start,1000)+"]","["+module+"]",msg);


### PR DESCRIPTION
This fixes the following error when running `test/node/info.js`:

    TypeError: output.log is not a function
	at BoxParser.Box.printHeader (/home/josephfrazier/workspace/mp4box.js/dist/mp4box.all.js:7436:9)
	at BoxParser.Box.print (/home/josephfrazier/workspace/mp4box.js/dist/mp4box.all.js:7448:7)
	at ISOFile.print (/home/josephfrazier/workspace/mp4box.js/dist/mp4box.all.js:7467:18)
	at Object.<anonymous> (/home/josephfrazier/workspace/mp4box.js/test/node/info.js:10:25)
	at Module._compile (internal/modules/cjs/loader.js:678:30)
	at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)
	at Module.load (internal/modules/cjs/loader.js:589:32)
	at tryModuleLoad (internal/modules/cjs/loader.js:528:12)
	at Function.Module._load (internal/modules/cjs/loader.js:520:3)
	at Function.Module.runMain (internal/modules/cjs/loader.js:719:10)

---------------------------------------------------------------

It's an alias for `.debug`, since they are aliased in Node/etc:

https://devdocs.io/node/console#console_console_debug_data_args

EDIT: I merged #149 into this to demonstrate that the tests still pass.