### PR TITLE
Don't require $NPM_TOKEN for Travis tests, only deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 node_js:
 - '6.0.0'
 before_install:
-- echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 - "export CHROME_BIN=chromium-browser"
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
@@ -14,6 +13,8 @@ before_script:
   - 'npm install karma'
   - 'npm install grunt-karma'
   - 'npm install karma-phantomjs-launcher'
+before_deploy:
+- echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 deploy:
   - provider: releases
     api_key:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,14 @@ module.exports = function(config) {
         frameworks: ['qunit'],
 
 
+        // client configuration
+        client: {
+          qunit: {
+            testTimeout: 5000
+          }
+        },
+
+
         // list of files / patterns to load in the browser
         files: [
           '../src/log.js',                       // logging system


### PR DESCRIPTION
I'm hoping this will make Travis more useful for pull requests.

EDIT: It looks like the tests passed, but the build stalled:

> No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
> Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
> 
> The build has been terminated
