### PR TITLE
fixes invalid created, modified date

### DIFF
--- a/src/isofile.js
+++ b/src/isofile.js
@@ -290,7 +290,7 @@ ISOFile.prototype.getInfo = function() {
 	var trak;
 	var track;
 	var sample_desc;
-	var _1904 = (new Date(4, 0, 1, 0, 0, 0, 0).getTime());
+	var _1904 = (new Date('1904-01-01T00:00:00Z').getTime());
 
 	if (this.moov) {
 		movie.hasMoov = true;


### PR DESCRIPTION
According to ISO/IEC 14496-12, creation_time is an integer that declares the creation time of the presentation (in seconds since midnight, Jan. 1, 1904, in UTC time).
var _1904 should also be in UTC time, while new Date(4, 0, 1, 0, 0, 0, 0).getTime() returns Jan. 1, 1904, in local time.