### PR TITLE
Ensure that sidx first offset is complete

### DIFF
--- a/src/parsing/sidx.js
+++ b/src/parsing/sidx.js
@@ -23,5 +23,6 @@ BoxParser.createFullBoxCtor("sidx", function(stream) {
 		ref.SAP_type = (tmp_32 >> 28) & 0x7;
 		ref.SAP_delta_time = tmp_32 & 0xFFFFFFF;
 	}
+	this.first_offset += stream.position;
 });
 


### PR DESCRIPTION
Found that the sidx `first_offset` was consistently off by the stream position, so I append this value to the final value to produce a correct offset.