### PR TITLE
Corrects the writing of avcC data

### DIFF
--- a/src/writing/avcC.js
+++ b/src/writing/avcC.js
@@ -19,13 +19,13 @@ BoxParser.avcCBox.prototype.write = function(stream) {
 	stream.writeUint8(this.SPS.length + (7<<5));
 	for (i = 0; i < this.SPS.length; i++) {
 		stream.writeUint16(this.SPS[i].length);
-		stream.writeUint8Array(this.SPS[i]);
+		stream.writeUint8Array(this.SPS[i].nalu);
 	}
 	stream.writeUint8(this.PPS.length);
 	for (i = 0; i < this.PPS.length; i++) {
 		stream.writeUint16(this.PPS[i].length);
-		stream.writeUint8Array(this.PPS[i]);
-	}	
+		stream.writeUint8Array(this.PPS[i].nalu);
+	}
 	if (this.ext) {
 		stream.writeUint8Array(this.ext);
 	}


### PR DESCRIPTION
Due to the refactor putting the buffer data in the `nalu` prop, this
fixes the writing.

Reference: https://github.com/gpac/mp4box.js/issues/154

Closes: #154 and #166