### PR TITLE
Write pssh boxes to generated moov box

### DIFF
--- a/src/isofile-write.js
+++ b/src/isofile-write.js
@@ -17,7 +17,7 @@ ISOFile.prototype.createFragment = function(track_id, sampleNumber, stream_) {
 		}
 		return null;
 	}
-	
+
 	var stream = stream_ || new DataStream();
 	stream.endianness = DataStream.BIG_ENDIAN;
 
@@ -28,7 +28,7 @@ ISOFile.prototype.createFragment = function(track_id, sampleNumber, stream_) {
 	moof.trafs[0].truns[0].data_offset = moof.size+8; //8 is mdat header
 	Log.debug("MP4Box", "Adjusting data_offset with new value "+moof.trafs[0].truns[0].data_offset);
 	stream.adjustUint32(moof.trafs[0].truns[0].data_offset_position, moof.trafs[0].truns[0].data_offset);
-		
+
 	var mdat = new BoxParser.mdatBox();
 	mdat.data = sample.data;
 	mdat.write(stream);
@@ -47,7 +47,7 @@ ISOFile.writeInitializationSegment = function(ftyp, moov, total_duration, sample
 	var stream = new DataStream();
 	stream.endianness = DataStream.BIG_ENDIAN;
 	ftyp.write(stream);
-	
+
 	/* we can now create the new mvex box */
 	var mvex = moov.add("mvex");
 	if (total_duration) {
@@ -70,7 +70,7 @@ ISOFile.prototype.save = function(name) {
 	var stream = new DataStream();
 	stream.endianness = DataStream.BIG_ENDIAN;
 	this.write(stream);
-	stream.save(name);	
+	stream.save(name);
 }
 
 ISOFile.prototype.getBuffer = function() {
@@ -91,15 +91,21 @@ ISOFile.prototype.initializeSegmentation = function() {
 		Log.warn("MP4Box", "No segmentation callback set!");
 	}
 	if (!this.isFragmentationInitialized) {
-		this.isFragmentationInitialized = true;		
+		this.isFragmentationInitialized = true;
 		this.nextMoofNumber = 0;
 		this.resetTables();
-	}	
-	initSegs = [];	
+	}
+	initSegs = [];
 	for (i = 0; i < this.fragmentedTracks.length; i++) {
 		var moov = new BoxParser.moovBox();
 		moov.mvhd = this.moov.mvhd;
 	    moov.boxes.push(moov.mvhd);
+
+      // Ensure pssh boxes are pushed into the generated moov box.
+      if (this.moov.psshs) {
+        moov.boxes.push.apply(moov.boxes, this.moov.psshs);
+      }
+
 		trak = this.getTrackById(this.fragmentedTracks[i].id);
 		moov.boxes.push(trak);
 		moov.traks.push(trak);

--- a/src/isofile-write.js
+++ b/src/isofile-write.js
@@ -99,16 +99,20 @@ ISOFile.prototype.initializeSegmentation = function() {
 	for (i = 0; i < this.fragmentedTracks.length; i++) {
 		var moov = new BoxParser.moovBox();
 		moov.mvhd = this.moov.mvhd;
-	    moov.boxes.push(moov.mvhd);
+		moov.boxes.push(moov.mvhd);
 
-      // Ensure pssh boxes are pushed into the generated moov box.
-      if (this.moov.psshs) {
-        moov.boxes.push.apply(moov.boxes, this.moov.psshs);
-      }
+		moov.boxes.push(this.moov.mvex);
 
 		trak = this.getTrackById(this.fragmentedTracks[i].id);
 		moov.boxes.push(trak);
 		moov.traks.push(trak);
+
+		// Ensure pssh boxes are pushed into the generated moov box.
+		if (this.moov.psshs) {
+			moov.psshs = this.moov.psshs;
+			moov.boxes.push.apply(moov.boxes, this.moov.psshs);
+		}
+
 		seg = {};
 		seg.id = trak.tkhd.track_id;
 		seg.user = this.fragmentedTracks[i].user;

--- a/src/writing/pssh.js
+++ b/src/writing/pssh.js
@@ -1,0 +1,30 @@
+// FIXME Does this function already exist in MP4Box?
+function toByteArray(hexString) {
+	var result = [];
+	while (hexString.length >= 2) {
+		result.push(parseInt(hexString.substring(0, 2), 16));
+		hexString = hexString.substring(2, hexString.length);
+	}
+	return new Uint8Array(result);
+}
+
+BoxParser.psshBox.prototype.write = function(stream) {
+	// Add the system id byte length.
+	var byteArray = toByteArray(this.system_id);
+
+	// Calculate the full box size.
+	this.size = this.hdr_size + this.data.byteLength + byteArray.byteLength + 4;
+
+	// Write out the BMFF box header.
+	stream.writeInt32(this.size);
+	stream.writeString(this.type, null, 4);
+
+	// Write out the full box header.
+	stream.writeUint8(this.version);
+	stream.writeUint24(this.flags);
+
+	// Write out the pssh data.
+	stream.writeUint8Array(byteArray);
+	stream.writeUint32(this.data.byteLength);
+	stream.writeUint8Array(this.data);
+}


### PR DESCRIPTION
Write the pssh boxes to the generated moov box when writing out during
segmentation initialization. This is required otherwise Chrome will not
trigger an onEncrypted event.