### PR TITLE
Add in missing variable declarations for compressorname_length and trak

### DIFF
--- a/src/isofile-sample-processing.js
+++ b/src/isofile-sample-processing.js
@@ -175,6 +175,7 @@ ISOFile.process_sdtp = function (sdtp, sample, number) {
 /* Build initial sample list from  sample tables */
 ISOFile.prototype.buildSampleLists = function() {	
 	var i;
+	var trak;
 	for (i = 0; i < this.moov.traks.length; i++) {
 		trak = this.moov.traks[i];
 		this.buildTrakSampleLists(trak);

--- a/src/parsing/sampleentries/sampleentry.js
+++ b/src/parsing/sampleentries/sampleentry.js
@@ -39,6 +39,7 @@ BoxParser.createMediaSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_TEXT);
 
 //Base SampleEntry types for Audio and Video with specific parsing
 BoxParser.createMediaSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_VISUAL, function(stream) {
+	var compressorname_length;
 	this.parseHeader(stream);
 	stream.readUint16();
 	stream.readUint16();


### PR DESCRIPTION
Fixes: throwing errors reporting that these two variables are not declared.