### PR TITLE
fix mfhd box sequence_number

### DIFF
--- a/src/isofile-advanced-creation.js
+++ b/src/isofile-advanced-creation.js
@@ -183,7 +183,7 @@ ISOFile.prototype.addSample = function (track_id, data, _options) {
 
 	this.processSamples();
 	
-	var moof = ISOFile.createSingleSampleMoof(sample);
+	var moof = this.createSingleSampleMoof(sample);
 	this.addBox(moof);
 	moof.computeSize();
 	/* adjusting the data_offset now that the moof size is known*/
@@ -192,7 +192,7 @@ ISOFile.prototype.addSample = function (track_id, data, _options) {
 	return sample;
 }
 
-ISOFile.createSingleSampleMoof = function(sample) {
+ISOFile.prototype.createSingleSampleMoof = function(sample) {
 	var moof = new BoxParser.moofBox();
 	moof.add("mfhd").set("sequence_number", this.nextMoofNumber);
 	this.nextMoofNumber++;

--- a/src/isofile-write.js
+++ b/src/isofile-write.js
@@ -21,7 +21,7 @@ ISOFile.prototype.createFragment = function(track_id, sampleNumber, stream_) {
 	var stream = stream_ || new DataStream();
 	stream.endianness = DataStream.BIG_ENDIAN;
 
-	var moof = ISOFile.createSingleSampleMoof(sample);
+	var moof = this.createSingleSampleMoof(sample);
 	moof.write(stream);
 
 	/* adjusting the data_offset now that the moof size is known*/


### PR DESCRIPTION
`sequence_number` is generated incorrectly because context is lost