### PR TITLE
Add support for generating version 1 TFDT boxes

### DIFF
--- a/src/writing/tfdt.js
+++ b/src/writing/tfdt.js
@@ -1,5 +1,8 @@
+var UINT32_MAX = Math.pow(2, 32) - 1;
+
 BoxParser.tfdtBox.prototype.write = function(stream) {
-	this.version = 0;
+	// use version 1 if baseMediaDecodeTime does not fit 32 bits
+	this.version = this.baseMediaDecodeTime > UINT32_MAX ? 1 : 0;
 	this.flags = 0;
 	this.size = 4;
 	if (this.version === 1) {


### PR DESCRIPTION
If `baseMediaDecodeTime` is high now it wraps and breaks live stream segments.

In this case TFDT version 1 should be used.