### PR TITLE
fix DataView constructor usage for IE10

### DIFF
--- a/src/DataStream.js
+++ b/src/DataStream.js
@@ -119,7 +119,7 @@ Object.defineProperty(DataStream.prototype, 'buffer',
     },
     set: function(v) {
       this._buffer = v;
-      this._dataView = new DataView(this._buffer, this._byteOffset);
+      this._dataView = this.dataViewSafely(this._buffer, this._byteOffset);
       this._byteLength = this._buffer.byteLength;
     } });
 
@@ -134,7 +134,7 @@ Object.defineProperty(DataStream.prototype, 'byteOffset',
     },
     set: function(v) {
       this._byteOffset = v;
-      this._dataView = new DataView(this._buffer, this._byteOffset);
+      this._dataView = this.dataViewSafely(this._buffer, this._byteOffset);
       this._byteLength = this._buffer.byteLength;
     } });
 
@@ -150,7 +150,7 @@ Object.defineProperty(DataStream.prototype, 'dataView',
     set: function(v) {
       this._byteOffset = v.byteOffset;
       this._buffer = v.buffer;
-      this._dataView = new DataView(this._buffer, this._byteOffset);
+      this._dataView = this.dataViewSafely(this._buffer, this._byteOffset);
       this._byteLength = this._byteOffset + v.byteLength;
     } });
 
@@ -579,6 +579,22 @@ DataStream.prototype.readInt64 = function () {
 
 DataStream.prototype.readUint24 = function () {
 	return (this.readUint8()<<16)+(this.readUint8()<<8)+this.readUint8();
+}
+
+/**
+ * reference : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView
+ * new DataView(new ArrayBuffer(0), 0) // produce error "DataView constructor argument offset is invalid"
+ * new DataView(new ArrayBuffer(0)) // OK
+ *
+ * @param {ArrayBuffer} buffer
+ * @param {?Number} byteOffset
+ */
+DataStream.prototype.dataViewSafely = function (buffer, byteOffset) {
+  if (buffer && buffer.byteLength === 0) {
+    this._dataView = new DataView(buffer);
+  } else {
+    this._dataView = new DataView(buffer, byteOffset);
+  }
 }
 
 if (typeof exports !== 'undefined') {

--- a/src/DataStream.js
+++ b/src/DataStream.js
@@ -119,7 +119,7 @@ Object.defineProperty(DataStream.prototype, 'buffer',
     },
     set: function(v) {
       this._buffer = v;
-      this._dataView = this.dataViewSafely(this._buffer, this._byteOffset);
+      this._dataView = this.createDataView(this._buffer, this._byteOffset);
       this._byteLength = this._buffer.byteLength;
     } });
 
@@ -134,7 +134,7 @@ Object.defineProperty(DataStream.prototype, 'byteOffset',
     },
     set: function(v) {
       this._byteOffset = v;
-      this._dataView = this.dataViewSafely(this._buffer, this._byteOffset);
+      this._dataView = this.createDataView(this._buffer, this._byteOffset);
       this._byteLength = this._buffer.byteLength;
     } });
 
@@ -150,7 +150,7 @@ Object.defineProperty(DataStream.prototype, 'dataView',
     set: function(v) {
       this._byteOffset = v.byteOffset;
       this._buffer = v.buffer;
-      this._dataView = this.dataViewSafely(this._buffer, this._byteOffset);
+      this._dataView = this.createDataView(this._buffer, this._byteOffset);
       this._byteLength = this._byteOffset + v.byteLength;
     } });
 
@@ -588,12 +588,13 @@ DataStream.prototype.readUint24 = function () {
  *
  * @param {ArrayBuffer} buffer
  * @param {?Number} byteOffset
+ * @return {DataView}
  */
-DataStream.prototype.dataViewSafely = function (buffer, byteOffset) {
+DataStream.prototype.createDataView = function (buffer, byteOffset) {
   if (buffer && buffer.byteLength === 0) {
-    this._dataView = new DataView(buffer);
+    return new DataView(buffer);
   } else {
-    this._dataView = new DataView(buffer, byteOffset);
+    return new DataView(buffer, byteOffset);
   }
 }
 


### PR DESCRIPTION
I had same issue with ie10 DataView. https://github.com/gpac/mp4box.js/issues/124
env : win7 IE10

reference : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView

``` javascript
new DataView(new ArrayBuffer(0), 0) // produce error "DataView constructor argument offset is invalid"
new DataView(new ArrayBuffer(0)) // OK
```