### PR TITLE
declare ref variable in getInfo

### DIFF
--- a/src/isofile.js
+++ b/src/isofile.js
@@ -299,6 +299,7 @@ ISOFile.prototype.getInfo = function() {
 	var movie = {};
 	var trak;
 	var track;
+	var ref;
 	var sample_desc;
 	var _1904 = (new Date('1904-01-01T00:00:00Z').getTime());
 


### PR DESCRIPTION
Without this mp4box.js cannot be used when "strict" mode is enabled.