### PR TITLE
fix: set next seek position if sample data is missing for extracted tracks samples

### DIFF
--- a/src/isofile-write.js
+++ b/src/isofile-write.js
@@ -9,12 +9,7 @@ ISOFile.prototype.createFragment = function(track_id, sampleNumber, stream_) {
 	var trak = this.getTrackById(track_id);
 	var sample = this.getSample(trak, sampleNumber);
 	if (sample == null) {
-		sample = trak.samples[sampleNumber];
-		if (this.nextSeekPosition) {
-			this.nextSeekPosition = Math.min(sample.offset+sample.alreadyRead,this.nextSeekPosition);
-		} else {
-			this.nextSeekPosition = trak.samples[sampleNumber].offset+sample.alreadyRead;
-		}
+		this.setNextSeekPositionFromSample(trak.samples[sampleNumber]);
 		return null;
 	}
 	

--- a/src/isofile.js
+++ b/src/isofile.js
@@ -414,6 +414,17 @@ ISOFile.prototype.getInfo = function() {
 	return movie;
 }
 
+ISOFile.prototype.setNextSeekPositionFromSample = function (sample) {
+	if (!sample) {
+		return;
+	}
+	if (this.nextSeekPosition) {
+		this.nextSeekPosition = Math.min(sample.offset+sample.alreadyRead,this.nextSeekPosition);
+	} else {
+		this.nextSeekPosition = sample.offset+sample.alreadyRead;
+	}
+}
+
 ISOFile.prototype.processSamples = function(last) {
 	var i;
 	var trak;
@@ -470,6 +481,7 @@ ISOFile.prototype.processSamples = function(last) {
 					trak.nextSample++;
 					extractTrak.samples.push(sample);
 				} else {
+					this.setNextSeekPositionFromSample(trak.samples[trak.nextSample]);
 					break;
 				}
 				if (trak.nextSample % extractTrak.nb_samples === 0 || trak.nextSample >= trak.samples.length) {


### PR DESCRIPTION
I found a problem with sample extraction: `nextSeekPosition` was never updated when samples were missing from buffers. This causes `onSamples` to not be called if the data is not already in the buffers as `appendBuffer` would never return the offset required for the sample extraction track.

I tried to fix it with this change, feel free to make changes / suggest a better solution.