### PR TITLE
fix(ISOFile.prototype.seek): skip already ended tracks

### DIFF
--- a/src/isofile.js
+++ b/src/isofile.js
@@ -598,6 +598,16 @@ ISOFile.prototype.seekTrack = function(time, useRap, trak) {
 	return { offset: seek_offset, time: time/timescale };
 }
 
+ISOFile.prototype.getTrackDuration = function (trak) {
+	var sample;
+
+	if (!trak.samples) {
+		return Infinity;
+	}
+	sample = trak.samples[trak.samples.length - 1];
+	return (sample.cts + sample.duration) / sample.timescale;
+}
+
 /* Finds the byte offset in the file corresponding to the given time or to the time of the previous RAP */
 ISOFile.prototype.seek = function(time, useRap) {
 	var moov = this.moov;
@@ -610,6 +620,9 @@ ISOFile.prototype.seek = function(time, useRap) {
 	} else {
 		for (i = 0; i<moov.traks.length; i++) {
 			trak = moov.traks[i];
+			if (time > this.getTrackDuration(trak)) { // skip tracks that already ended
+				continue;
+			}
 			trak_seek_info = this.seekTrack(time, useRap, trak);
 			if (trak_seek_info.offset < seek_info.offset) {
 				seek_info.offset = trak_seek_info.offset;


### PR DESCRIPTION
Fix issue with files that have some tracks that don't extend the whole duration of the video. `ISOFile.prototype.seek` would return the offset based on already ended tracks and thus cause unnecessary downloads/buffering. Tried to explain behaviour below:

Before:
```
Video track 1: ====================================
Audio track 1: ====================================
Audio track 2: ===========
                          ^                  ^
                  returned offset           seek
```

After:
```
Video track 1: ====================================
Audio track 1: ====================================
Audio track 2: ===========
                                             ^
                                   seek & returned offset
```