### PR TITLE
bugfix: set first_dts

### DIFF
--- a/src/isofile-advanced-creation.js
+++ b/src/isofile-advanced-creation.js
@@ -179,7 +179,7 @@ ISOFile.prototype.addSample = function (track_id, data, _options) {
 	trak.samples.push(sample);
 	trak.samples_size += sample.size;
 	trak.samples_duration += sample.duration;
-	if (!trak.first_dts) {
+	if (trak.first_dts === undefined) {
 		trak.first_dts = options.dts;
 	}
 


### PR DESCRIPTION
first_dts setted as the first > 0 number instead of the real first one.
and that will make the video has the head 2 frames start from 0 timestamp.