### PR TITLE
Add j2kH & cdef Box definitions

### DIFF
--- a/src/box.js
+++ b/src/box.js
@@ -36,7 +36,8 @@ var BoxParser = {
 		[ "trgr" ],
 		[ "udta", ["kind"] ],
 		[ "iprp", ["ipma"] ],
-		[ "ipco"]
+		[ "ipco" ],
+		[ "j2kH" ]
 	],
 	// Boxes effectively created
 	boxCodes : [],

--- a/src/parsing/cdef.js
+++ b/src/parsing/cdef.js
@@ -1,0 +1,13 @@
+BoxParser.createBoxCtor("cdef", function(stream) {
+    var i;
+    this.channel_count = stream.readUint16();
+    this.channel_indexes = [];
+    this.channel_types = [];
+    this.channel_associations = [];
+    for (i = 0; i < this.channel_count; i++) {
+        this.channel_indexes.push(stream.readUint16());
+        this.channel_types.push(stream.readUint16());
+        this.channel_associations.push(stream.readUint16());
+    }
+});
+


### PR DESCRIPTION
The '_j2kH_' box:
- is named the J2KHeaderItemProperty or J2KHeaderInfo box. 
- is a superbox, which means that it only contains other boxes
- is defined in ISO/IEC 15444-16
- is used to store JPEG 2000 metadata


The '_cdef_' box:
- is named the Channel Definition box.
- is defined in ISO/IEC 15444-1.
- shall be present in the j2kH box.
- Provides channel information. (RGB, Grayscale, YCC, etc.)

