### PR TITLE
iref: show to_item_ID value

### DIFF
--- a/src/parsing/singleitemtypereference.js
+++ b/src/parsing/singleitemtypereference.js
@@ -9,7 +9,8 @@ BoxParser.SingleItemTypeReferenceBox.prototype.parse = function(stream) {
 	var count =  stream.readUint16();
 	this.references = [];
 	for(var i = 0; i < count; i++) {
-		this.references[i] = stream.readUint16();
+		this.references[i] = {};
+		this.references[i].to_item_ID = stream.readUint16();
 	}
 }
 

--- a/src/parsing/singleitemtypereferencelarge.js
+++ b/src/parsing/singleitemtypereferencelarge.js
@@ -9,7 +9,8 @@ BoxParser.SingleItemTypeReferenceBoxLarge.prototype.parse = function(stream) {
 	var count =  stream.readUint16();
 	this.references = [];
 	for(var i = 0; i < count; i++) {
-		this.references[i] = stream.readUint32();
+		this.references[i] = {};
+		this.references[i].to_item_ID = stream.readUint32();
 	}
 }
 


### PR DESCRIPTION
This enables the `to_item_ID` from SingleItemReferenceBox and SingleItemReferenceBoxLarge to be displayed in the box view (rather than just a leaf node).

Example that shows this: https://github.com/nokiatech/heif_conformance/raw/master/conformance_files/C005.heic (on the `thmb` .

Before:
![image](https://user-images.githubusercontent.com/174642/231421244-26866c16-3bb2-4bb1-9077-d070cd83272e.png)

After:
![image](https://user-images.githubusercontent.com/174642/231421435-133653e7-d9d9-4544-b354-9527cf70ca39.png)
