### PR TITLE
ccst: parse out coding contraint box

### DIFF
--- a/src/parsing/ccst.js
+++ b/src/parsing/ccst.js
@@ -1,0 +1,8 @@
+BoxParser.createFullBoxCtor("ccst", function(stream) {
+	var flags = stream.readUint8();
+	this.all_ref_pics_intra = ((flags & 0x80) == 0x80);
+	this.intra_pred_used = ((flags & 0x40) == 0x40);
+	this.max_ref_per_pic = ((flags & 0x3f) >> 2);
+	stream.readUint24();
+});
+


### PR DESCRIPTION
See ISO/IEC 23008-12:2022 Section 7.2.3

For a sample that uses this, see https://github.com/nokiatech/heif_conformance/raw/master/conformance_files/C038.heic