### PR TITLE
improve group and property handling

### DIFF
--- a/src/isofile-item-processing.js
+++ b/src/isofile-item-processing.js
@@ -1,9 +1,11 @@
 ISOFile.prototype.items = [];
+ISOFile.prototype.groups = [];
 /* size of the buffers allocated for samples */
 ISOFile.prototype.itemsDataSize = 0;
 
 ISOFile.prototype.flattenItemInfo = function() {	
 	var items = this.items;
+	var groups = this.groups;
 	var i, j;
 	var item;
 	var meta = this.meta;
@@ -26,6 +28,15 @@ ISOFile.prototype.flattenItemInfo = function() {
 		}
 		item.content_type = meta.iinf.item_infos[i].content_type;
 		item.content_encoding = meta.iinf.item_infos[i].content_encoding;
+	}
+	if (meta.grpl) {
+		for (i = 0; i < meta.grpl.boxes.length; i++) {
+			group = {};
+			group.id = meta.grpl.boxes[i].group_id;
+			group.entity_ids = meta.grpl.boxes[i].entity_ids;
+			group.type = meta.grpl.boxes[i].type;
+			groups[group.id] = group;
+		}
 	}
 	if (meta.iloc) {
 		for(i = 0; i < meta.iloc.items.length; i++) {
@@ -74,16 +85,21 @@ ISOFile.prototype.flattenItemInfo = function() {
 			for (i = 0; i < ipma.associations.length; i++) {
 				var association = ipma.associations[i];
 				item = items[association.id];
-				if (item.properties === undefined) {
-					item.properties = {};
-					item.properties.boxes = [];
+				if (!item) {
+					item = groups[association.id];
 				}
-				for (j = 0; j < association.props.length; j++) {
-					var propEntry = association.props[j];
-					if (propEntry.property_index > 0 && propEntry.property_index-1 < meta.iprp.ipco.boxes.length) {
-						var propbox = meta.iprp.ipco.boxes[propEntry.property_index-1];
-						item.properties[propbox.type] = propbox;
-						item.properties.boxes.push(propbox);
+				if (item) {
+					if (item.properties === undefined) {
+						item.properties = {};
+						item.properties.boxes = [];
+					}
+					for (j = 0; j < association.props.length; j++) {
+						var propEntry = association.props[j];
+						if (propEntry.property_index > 0 && propEntry.property_index-1 < meta.iprp.ipco.boxes.length) {
+							var propbox = meta.iprp.ipco.boxes[propEntry.property_index-1];
+							item.properties[propbox.type] = propbox;
+							item.properties.boxes.push(propbox);
+						}
 					}
 				}
 			}

--- a/src/isofile-item-processing.js
+++ b/src/isofile-item-processing.js
@@ -1,11 +1,11 @@
 ISOFile.prototype.items = [];
-ISOFile.prototype.groups = [];
+ISOFile.prototype.entity_groups = [];
 /* size of the buffers allocated for samples */
 ISOFile.prototype.itemsDataSize = 0;
 
 ISOFile.prototype.flattenItemInfo = function() {	
 	var items = this.items;
-	var groups = this.groups;
+	var entity_groups = this.entity_groups;
 	var i, j;
 	var item;
 	var meta = this.meta;
@@ -31,11 +31,11 @@ ISOFile.prototype.flattenItemInfo = function() {
 	}
 	if (meta.grpl) {
 		for (i = 0; i < meta.grpl.boxes.length; i++) {
-			group = {};
-			group.id = meta.grpl.boxes[i].group_id;
-			group.entity_ids = meta.grpl.boxes[i].entity_ids;
-			group.type = meta.grpl.boxes[i].type;
-			groups[group.id] = group;
+			entity_group = {};
+			entity_group.id = meta.grpl.boxes[i].group_id;
+			entity_group.entity_ids = meta.grpl.boxes[i].entity_ids;
+			entity_group.type = meta.grpl.boxes[i].type;
+			entity_groups[entity_group.id] = entity_group;
 		}
 	}
 	if (meta.iloc) {
@@ -86,7 +86,7 @@ ISOFile.prototype.flattenItemInfo = function() {
 				var association = ipma.associations[i];
 				item = items[association.id];
 				if (!item) {
-					item = groups[association.id];
+					item = entity_groups[association.id];
 				}
 				if (item) {
 					if (item.properties === undefined) {

--- a/test/filereader.html
+++ b/test/filereader.html
@@ -145,6 +145,7 @@
 		    <li><a href="#sampleview">Sample View</a></li>
 		    <li><a href="#itemview">Item View</a></li>
 		    <li><a href="#segmentview">Segment View</a></li>
+		    <li><a href="#groupview">Group View</a></li>
 		  </ul>
 			<div id="movieview">
 			</div>
@@ -212,6 +213,8 @@
 					<div id="segmenttable"></div>
 					<div id="segmentgraph"></div>
 				</div>
+			</div>
+			<div id="groupview">
 			</div>
 		</div>
 	</body>

--- a/test/filereader.html
+++ b/test/filereader.html
@@ -144,8 +144,9 @@
 		    <li><a href="#boxview">Box View</a></li>
 		    <li><a href="#sampleview">Sample View</a></li>
 		    <li><a href="#itemview">Item View</a></li>
+		    <li><a href="#entitygroupview">Entity Group View</a></li>
 		    <li><a href="#segmentview">Segment View</a></li>
-		    <li><a href="#groupview">Group View</a></li>
+
 		  </ul>
 			<div id="movieview">
 			</div>
@@ -202,6 +203,8 @@
 			</div>
 			<div id="itemview">
 			</div>
+			<div id="entitygroupview">
+			</div>
 			<div id="segmentview">
 				<label>View type:<select name="segmentviewselector" id="segmentviewselector">
 					<option selected="selected">Segment Table</option>
@@ -213,8 +216,6 @@
 					<div id="segmenttable"></div>
 					<div id="segmentgraph"></div>
 				</div>
-			</div>
-			<div id="groupview">
 			</div>
 		</div>
 	</body>

--- a/test/filereader.js
+++ b/test/filereader.js
@@ -28,14 +28,14 @@ function finalizeAnalyzerUI(fileobj, loadbutton, success) {
 		buildSampleView();
 		displayMovieInfo(fileobj.mp4boxfile.getInfo(), document.getElementById("movieview"), false);
 		buildSegmentView(fileobj);
-		buildGroupTable(fileobj.mp4boxfile.groups);
+		buildEntityGroupTable(fileobj.mp4boxfile.entity_groups);
 	} else {
 		resetBoxView();
 		$("#itemview").html('');
 		resetSampleView();
 		$("#movieview").html('');
 		resetSegmentView();
-		$("#groupview").html('');
+		$("#entitygroupview").html('');
 	}
 }
 
@@ -421,28 +421,28 @@ function buildSegmentView(fileobj) {
 	buildSegmentGraph(sidx, startSeg, endSeg);
 }
 
-function buildGroupTable(groups) {
+function buildEntityGroupTable(entity_groups) {
 	var html;
 	var i, j;
 	html = "<table>";
 	html += "<thead>";
 	html += "<tr>";
-	html += "<th>Group ID</th>";
+	html += "<th>Entity Group ID</th>";
 	html += "<th>Type</th>";
 	html += "<th>Entities [item ID]</th>";
 	html += "<th>Properties [type]</th>";
 	html += "</tr>";
 	html += "</thead>";
 	html += "<tbody>";
-	for (i in groups) {
-		var group = groups[i];
-		html += "<td>" + group.id + "</td>";
-		html += "<td>" + group.type + "</td>";
-		html += "<td>" + group.entity_ids.join() + "</td>";
+	for (i in entity_groups) {
+		var entity_group = entity_groups[i];
+		html += "<td>" + entity_group.id + "</td>";
+		html += "<td>" + entity_group.type + "</td>";
+		html += "<td>" + entity_group.entity_ids.join() + "</td>";
 		html += "<td>";
-		if (group.properties) {
-			for (j = 0; j < group.properties.boxes.length; j++) {
-				html += "" + group.properties.boxes[j].type + " ";
+		if (entity_group.properties) {
+			for (j = 0; j < entity_group.properties.boxes.length; j++) {
+				html += "" + entity_group.properties.boxes[j].type + " ";
 			}
 		}
 		html += "</td>";
@@ -450,7 +450,7 @@ function buildGroupTable(groups) {
 	}
 	html += "</tbody>";
 	html += "</table>";
-	$("#groupview").html(html);
+	$("#entitygroupview").html(html);
 }
 
 

--- a/test/filereader.js
+++ b/test/filereader.js
@@ -28,12 +28,14 @@ function finalizeAnalyzerUI(fileobj, loadbutton, success) {
 		buildSampleView();
 		displayMovieInfo(fileobj.mp4boxfile.getInfo(), document.getElementById("movieview"), false);
 		buildSegmentView(fileobj);
+		buildGroupTable(fileobj.mp4boxfile.groups);
 	} else {
 		resetBoxView();
 		$("#itemview").html('');
 		resetSampleView();
 		$("#movieview").html('');
 		resetSegmentView();
+		$("#groupview").html('');
 	}
 }
 
@@ -418,6 +420,39 @@ function buildSegmentView(fileobj) {
 
 	buildSegmentGraph(sidx, startSeg, endSeg);
 }
+
+function buildGroupTable(groups) {
+	var html;
+	var i, j;
+	html = "<table>";
+	html += "<thead>";
+	html += "<tr>";
+	html += "<th>Group ID</th>";
+	html += "<th>Type</th>";
+	html += "<th>Entities [item ID]</th>";
+	html += "<th>Properties [type]</th>";
+	html += "</tr>";
+	html += "</thead>";
+	html += "<tbody>";
+	for (i in groups) {
+		var group = groups[i];
+		html += "<td>" + group.id + "</td>";
+		html += "<td>" + group.type + "</td>";
+		html += "<td>" + group.entity_ids.join() + "</td>";
+		html += "<td>";
+		if (group.properties) {
+			for (j = 0; j < group.properties.boxes.length; j++) {
+				html += "" + group.properties.boxes[j].type + " ";
+			}
+		}
+		html += "</td>";
+		html += "</tr>";
+	}
+	html += "</tbody>";
+	html += "</table>";
+	$("#groupview").html(html);
+}
+
 
 window.onload = function () {
 


### PR DESCRIPTION
Prior to this change,  property processing will throw if the association is not found in the item list. That can happen because the association is broken, and can also happen on a valid file if the property is associated with a group rather than a single item. 

This change links the property to either the item or the group, and protects against the case where the association is not valid against either.

It also adds display of groups (including entity IDs, and properties) to the filereader UI.

![image](https://user-images.githubusercontent.com/174642/232760025-114b0746-29a5-43d2-b6c8-0b0cfd7ea301.png)

(This shows a slightly different styling - `th` is `text-align: left;` instead of `text-align: center;` - happy to propose that as a follow-up change if desired).

For an example that shows the problem (and displays in the new UI), see https://github.com/nokiatech/heif_conformance/raw/master/conformance_files/C050.heic