### PR TITLE
iloc version bug

### DIFF
--- a/src/parsing/iloc.js
+++ b/src/parsing/iloc.js
@@ -26,7 +26,7 @@ BoxParser.createFullBoxCtor("iloc", function(stream) {
 		if (this.version < 2) {
 			item.item_ID = stream.readUint16();
 		} else if (this.version === 2) {
-			item.item_ID = stream.readUint16();
+			item.item_ID = stream.readUint32();
 		} else {
 			throw "version of iloc box not supported";
 		}


### PR DESCRIPTION
When the iloc box version is 2, the item_ID should be a parsed as a 32 bit unsigned integer, not 16. 