### PR TITLE
Add 'taic' box - TAIClockInfoBox

### DIFF
--- a/src/parsing/taic.js
+++ b/src/parsing/taic.js
@@ -1,0 +1,6 @@
+BoxParser.createFullBoxCtor("taic", function(stream) {
+	this.time_uncertainty = stream.readUint64();
+	this.correction_offset = stream.readInt64();
+	this.clock_drift_rate = stream.readFloat32();
+	this.reference_source_type = stream.readUint8();
+});


### PR DESCRIPTION
The *'taic'* box provides a mechanism to include 64-bit nanosecond time stamps, for media items and media track samples based on International Atomic Time (TAI). 

It falls under the MPEG #143 contribution, section 6.1.12.