### PR TITLE
Fix a bug that could cause negative general_profile_compatibility hex value to be set

### DIFF
--- a/src/box-codecs.js
+++ b/src/box-codecs.js
@@ -132,7 +132,7 @@ BoxParser.hvc1SampleEntry.prototype.getCodec = function() {
 			reversed <<= 1;
 			val >>=1;
 		}
-		baseCodec += BoxParser.decimalToHex(reversed, 0);
+		baseCodec += BoxParser.decimalToHex(reversed >>> 0, 0);
 		baseCodec += '.';
 		if (this.hvcC.general_tier_flag === 0) {
 			baseCodec += 'L';


### PR DESCRIPTION
Bug: if general_profile_compatibility negative after reverse, then decimalToHex() returns negative hex value.
Mime codecs string, generated by test/node/mp4codec.js will be wrong. This pull request fixes this.
