### PR TITLE
Add Timestamp boxes

### DIFF
--- a/src/parsing/itai.js
+++ b/src/parsing/itai.js
@@ -1,4 +1,4 @@
 BoxParser.createFullBoxCtor("itai", function(stream) {
-	this.TAI_time_stamp = stream.readUint64();
+	this.TAI_timestamp = stream.readUint64();
 	this.status_bits = stream.readUint8();
 });

--- a/src/parsing/itai.js
+++ b/src/parsing/itai.js
@@ -1,8 +1,8 @@
 BoxParser.createFullBoxCtor("itai", function(stream) {
 	this.TAI_timestamp = stream.readUint64();
-	this.status_bits = stream.readUint8();
 
-	if (this.TAI_timestamp === 0xffffffffffffffff) {
-		this.TAI_timestamp = "unknown";
-	}
+	status_bits = stream.readUint8();
+	this.sychronization_state = (status_bits >> 7) & 0x01;
+	this.timestamp_generation_failure = (status_bits >> 6) & 0x01;
+	this.timestamp_is_modified = (status_bits >> 5) & 0x01;
 });

--- a/src/parsing/itai.js
+++ b/src/parsing/itai.js
@@ -1,0 +1,4 @@
+BoxParser.createFullBoxCtor("itai", function(stream) {
+	this.TAI_time_stamp = stream.readUint64();
+	this.status_bits = stream.readUint8();
+});

--- a/src/parsing/itai.js
+++ b/src/parsing/itai.js
@@ -1,4 +1,8 @@
 BoxParser.createFullBoxCtor("itai", function(stream) {
 	this.TAI_timestamp = stream.readUint64();
 	this.status_bits = stream.readUint8();
+
+	if (this.TAI_timestamp === 0xffffffffffffffff) {
+		this.TAI_timestamp = "unknown";
+	}
 });

--- a/src/parsing/taic.js
+++ b/src/parsing/taic.js
@@ -1,0 +1,6 @@
+BoxParser.createFullBoxCtor("taic", function(stream) {
+	this.time_uncertainty = stream.readUint64();
+	this.correction_offset = stream.readInt64();
+	this.clock_drift_rate = stream.readFloat32();
+	this.reference_source_type = stream.readUint8();
+});

--- a/src/parsing/taic.js
+++ b/src/parsing/taic.js
@@ -2,8 +2,13 @@ BoxParser.createFullBoxCtor("taic", function(stream) {
 	this.time_uncertainty = stream.readUint64();
 	this.correction_offset = stream.readInt64();
 	this.clock_drift_rate = stream.readFloat32();
-	//if (clock_drift_rate == 0x7FC0 0000)
-	//	value is an IEEE 754 quiet NaN.
-	//	Interpret the value as unknown 
 	this.clock_source = stream.readUint8();
+
+	if (this.time_uncertainty === 0xffffffffffffffff) {
+		this.time_uncertainty = "unknown";
+	}
+
+	if (this.correction_offset === 0x7fffffffffffffff) {
+		this.correction_offset = "unknown";
+	}
 });

--- a/src/parsing/taic.js
+++ b/src/parsing/taic.js
@@ -1,14 +1,12 @@
 BoxParser.createFullBoxCtor("taic", function(stream) {
 	this.time_uncertainty = stream.readUint64();
-	this.correction_offset = stream.readInt64();
-	this.clock_drift_rate = stream.readFloat32();
-	this.clock_source = stream.readUint8();
+	this.clock_resolution = stream.readUint32();
+	this.clock_drift_rate = stream.readInt32();
+	this.clock_type = stream.readUint8();
 
 	if (this.time_uncertainty === 0xffffffffffffffff) {
 		this.time_uncertainty = "unknown";
 	}
 
-	if (this.correction_offset === 0x7fffffffffffffff) {
-		this.correction_offset = "unknown";
-	}
+
 });

--- a/src/parsing/taic.js
+++ b/src/parsing/taic.js
@@ -2,5 +2,8 @@ BoxParser.createFullBoxCtor("taic", function(stream) {
 	this.time_uncertainty = stream.readUint64();
 	this.correction_offset = stream.readInt64();
 	this.clock_drift_rate = stream.readFloat32();
-	this.reference_source_type = stream.readUint8();
+	//if (clock_drift_rate == 0x7FC0 0000)
+	//	value is an IEEE 754 quiet NaN.
+	//	Interpret the value as unknown 
+	this.clock_source = stream.readUint8();
 });


### PR DESCRIPTION
The *taic* & *itai* boxes are new boxes defined in the Draft Text for CD 23001-17 AMD 1. They provide information about the source clock as well as a nano-precision timestamp. 