### PR TITLE
add support for iloc construction method 1

### DIFF
--- a/src/isofile-item-processing.js
+++ b/src/isofile-item-processing.js
@@ -51,7 +51,6 @@ ISOFile.prototype.flattenItemInfo = function() {
 				case 0: // offset into the file referenced by the data reference index
 				break;
 				case 1: // offset into the idat box of this meta box
-				Log.warn("Item storage with construction_method : not supported");
 				break;
 				case 2: // offset into another item
 				Log.warn("Item storage with construction_method : not supported");
@@ -62,6 +61,9 @@ ISOFile.prototype.flattenItemInfo = function() {
 			for (j = 0; j < itemloc.extents.length; j++) {
 				item.extents[j] = {};
 				item.extents[j].offset = itemloc.extents[j].extent_offset + itemloc.base_offset;
+				if (itemloc.construction_method == 1) {
+					item.extents[j].offset += meta.idat.start + meta.idat.hdr_size;
+				}
 				item.extents[j].length = itemloc.extents[j].extent_length;
 				item.extents[j].alreadyRead = 0;
 				item.size += item.extents[j].length;


### PR DESCRIPTION
This means offset from the start of the iloc box content, and is implemented by adjusting the flattened offsets to match.

Thanks to @NuriaJulia for identifying the issue and the analysis.