### PR TITLE
cmpd: fix parsing

### DIFF
--- a/src/parsing/cmpd.js
+++ b/src/parsing/cmpd.js
@@ -1,9 +1,9 @@
 BoxParser.createBoxCtor("cmpd", function(stream) {
-	this.component_count = stream.readUint16();
+	this.component_count = stream.readUint32();
 	this.component_types = [];
 	this.component_type_urls = [];
 	for (i = 0; i < this.component_count; i++) {
-		var component_type = stream.readUint32();
+		var component_type = stream.readUint16();
 		this.component_types.push(component_type);
 		if (component_type >= 0x8000) {
 			this.component_type_urls.push(stream.readCString());


### PR DESCRIPTION
The previous update for FDIS compatibility was wrong for this box.

The size of the component should have been unchanged. Only the component count should be 32 bits.

Thanks to @dukesook and @EnvitiaAlexScottJohns for the diagnosis.