### PR TITLE
tkhd: Make the width & height human-readable

### DIFF
--- a/src/parsing/tkhd.js
+++ b/src/parsing/tkhd.js
@@ -20,5 +20,8 @@ BoxParser.createFullBoxCtor("tkhd", function(stream) {
 	this.matrix = stream.readInt32Array(9);
 	this.width = stream.readUint32();
 	this.height = stream.readUint32();
+
+	this.width = this.width >>> 16;
+	this.height = this.height >>> 16;
 });
 


### PR DESCRIPTION
Since the tkhd width and height are represented as 16.16 fixed point numbers, their values as displayed in MP4Box.js are meaningless.
![image](https://github.com/gpac/mp4box.js/assets/26695634/6ea3f2b0-f89a-4f26-92eb-f4122d636aa7)

This PR discards the lower 16 bits, which makes the width & height values useful.
![image](https://github.com/gpac/mp4box.js/assets/26695634/ea579543-ad0c-4a5e-95ac-c61c09630476)

