### PR TITLE
Fixed ESDS size parsing

### DIFF
--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -32,11 +32,11 @@ var MPEG4DescriptorParser = function () {
 		byteRead = stream.readUint8();
 		hdrSize++;
 		while (byteRead & 0x80) {
-			size = (byteRead & 0x7F)<<7;
+			size = (size << 7) + (byteRead & 0x7F);
 			byteRead = stream.readUint8();
 			hdrSize++;
 		}
-		size += byteRead & 0x7F;
+		size = (size << 7) + (byteRead & 0x7F);
 		Log.debug("MPEG4DescriptorParser", "Found "+(descTagToName[tag] || "Descriptor "+tag)+", size "+size+" at position "+stream.getPosition());
 		if (descTagToName[tag]) {
 			desc = new classes[descTagToName[tag]](size);


### PR DESCRIPTION
Resolved a logic error occurring when the size exceeds 2 bytes. Please, refer to the [Chromium source code](https://chromium.googlesource.com/chromium/src/media/+/16ba1c56b860d53d7354c0ec9538650cf1f20e2d/mp4/es_descriptor.cc#21) 