### PR TITLE
doc: Fix variable naming inconsistency in MP4Box initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Indicates that no more data will be received and that all remaining samples shou
 ### Segmentation ###
 
 ```javascript
-var mp4box = MP4Box.createFile();
+var mp4boxfile = MP4Box.createFile();
 mp4boxfile.onReady = function(info) {
   ...
   mp4boxfile.onSegment = function (id, user, buffer, sampleNumber, last) {}


### PR DESCRIPTION
### Description
updated README.md to fix a variable naming inconsistency mistake in mp4boxfile initialization. The mistake is in the code for the Segmentation example. 

should be:
``` js
var mp4boxfile = MP4Box.createFile();
mp4boxfile.onReady = function(info) {
  ...
};
```
not:
``` js
var mp4box = MP4Box.createFile();
mp4boxfile.onReady = function(info) {
  ...
};
```

### Changes
Renamed the variable `mp4box` to `mp4boxfile` for consistency throughout the codebase.