### PR TITLE
Adds check to emit fragments on keyframe boundaries when rapAlignement is set

### DIFF
--- a/src/isofile.js
+++ b/src/isofile.js
@@ -449,9 +449,11 @@ ISOFile.prototype.processSamples = function(last) {
 					/* The fragment could not be created because the media data is not there (not downloaded), wait for it */
 					break;
 				}
+				var nextSample = trak.samples[trak.nextSample];
+				var emitForRapBoundary = fragTrak.rapAlignement && nextSample && nextSample.is_sync;
 				/* A fragment is created by sample, but the segment is the accumulation in the buffer of these fragments.
 				   It is flushed only as requested by the application (nb_samples) to avoid too many callbacks */
-				if (trak.nextSample % fragTrak.nb_samples === 0 || (last || trak.nextSample >= trak.samples.length)) {
+				if (emitForRapBoundary || trak.nextSample % fragTrak.nb_samples === 0 || (last || trak.nextSample >= trak.samples.length)) {
 					Log.info("ISOFile", "Sending fragmented data on track #"+fragTrak.id+" for samples ["+Math.max(0,trak.nextSample-fragTrak.nb_samples)+","+(trak.nextSample-1)+"]");
 					Log.info("ISOFile", "Sample data size in memory: "+this.getAllocatedSampleDataSize());
 					if (this.onSegment) {


### PR DESCRIPTION
Related to #30.

I'm not sure how to approach adding a test for this because the `.mp4` files are not present in the repository, but this has been successful for me.

I do think that it might be better to make the nb_samples and rapAlignment options mutually exclusive.