### PR TITLE
saiz: add sample_count to box structure

### DIFF
--- a/src/parsing/saiz.js
+++ b/src/parsing/saiz.js
@@ -4,10 +4,10 @@ BoxParser.createFullBoxCtor("saiz", function(stream) {
 		this.aux_info_type_parameter = stream.readUint32();
 	}
 	this.default_sample_info_size = stream.readUint8();
-	var count = stream.readUint32();
+	this.sample_count = stream.readUint32();
 	this.sample_info_size = [];
 	if (this.default_sample_info_size === 0) {
-		for (var i = 0; i < count; i++) {
+		for (var i = 0; i < this.sample_count; i++) {
 			this.sample_info_size[i] = stream.readUint8();
 		}
 	}


### PR DESCRIPTION
This is useful when the `default_sample_info_size` is used and there are no entries in the `sample_info_size` array.

Resolves #390.