### PR TITLE
Fix problem that every instance shares same items list

### DIFF
--- a/src/isofile-item-processing.js
+++ b/src/isofile-item-processing.js
@@ -1,5 +1,3 @@
-ISOFile.prototype.items = [];
-ISOFile.prototype.entity_groups = [];
 /* size of the buffers allocated for samples */
 ISOFile.prototype.itemsDataSize = 0;
 

--- a/src/isofile.js
+++ b/src/isofile.js
@@ -43,6 +43,10 @@ var ISOFile = function (stream) {
 	this.nextMoofNumber = 0;
 	/* Boolean indicating if the initial list of items has been produced */
 	this.itemListBuilt = false;
+	/* Array of items */
+	this.items = [];
+	/* Array of entity groups */
+	this.entity_groups = [];
 	/* Callback called when the sidx box is entirely parsed */
 	this.onSidx = null;
 	/* Boolean keeping track of the call to onSidx, to avoid double calls */


### PR DESCRIPTION
Every instances of `ISOFile` are sharing same `items`, `entity_groups` list. 