### PR TITLE
Parse aux_info_type as string

### DIFF
--- a/src/parsing/saio.js
+++ b/src/parsing/saio.js
@@ -1,6 +1,6 @@
 BoxParser.createFullBoxCtor("saio", function(stream) {
 	if (this.flags & 0x1) {
-		this.aux_info_type = stream.readUint32();
+		this.aux_info_type = stream.readString(4);
 		this.aux_info_type_parameter = stream.readUint32();
 	}
 	var count = stream.readUint32();

--- a/src/parsing/saiz.js
+++ b/src/parsing/saiz.js
@@ -1,6 +1,6 @@
 BoxParser.createFullBoxCtor("saiz", function(stream) {
 	if (this.flags & 0x1) {
-		this.aux_info_type = stream.readUint32();
+		this.aux_info_type = stream.readString(4);
 		this.aux_info_type_parameter = stream.readUint32();
 	}
 	this.default_sample_info_size = stream.readUint8();


### PR DESCRIPTION
Currently, MP4Box.js displays the aux_info_type parameter in the saiz/saio boxes as a decimal value (e.g. **1635017065)**. Displaying this value as a string would be much more convenient (e.g. **'atai'**).


<!--EndFragment-->
</body>
</html>


<img width="347" alt="image" src="https://github.com/user-attachments/assets/6fffccd7-b502-45f2-beed-84f83a6dbf67">

<img width="329" alt="image" src="https://github.com/user-attachments/assets/250993e0-f1d0-4b00-affc-8a2d63506dde">

