### PR TITLE
Fix parsing Flac boxes

### DIFF
--- a/src/parsing/dfLa.js
+++ b/src/parsing/dfLa.js
@@ -14,9 +14,6 @@ BoxParser.createFullBoxCtor("dfLa", function(stream) {
         "RESERVED"
     ];
 
-    // dfLa is a FullBox
-    this.parseFullHeader(stream);
-
     // for (i=0; ; i++) { // to end of box
     do {
         var flagAndType = stream.readUint8();

--- a/src/parsing/sampleentries/sampleentry.js
+++ b/src/parsing/sampleentries/sampleentry.js
@@ -104,6 +104,7 @@ BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mha1");
 BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mha2");
 BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mhm1");
 BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mhm2");
+BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"fLaC");
 
 // Encrypted sample entries
 BoxParser.createEncryptedSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_VISUAL, 	"encv");


### PR DESCRIPTION
Original Flac parsing implementation from https://github.com/gpac/mp4box.js/pull/134, was broken due to prior refactoring. This pull request restores functionality by adding back the `fLaC` box to the sample entry list, and removing the extra header parse call in `dfLa.js`