### PR TITLE
Add support for AVS3 video and AVS3 audio in MP4

### DIFF
--- a/src/box-codecs.js
+++ b/src/box-codecs.js
@@ -266,12 +266,12 @@ BoxParser.av01SampleEntry.prototype.getCodec = function() {
 
 BoxParser.avs3SampleEntry.prototype.getCodec = function() {
 	var baseCodec = BoxParser.SampleEntry.prototype.getCodec.call(this);
-	return baseCodec + '.' + (this.av3c.profile_id ? this.av3c.profile_id.getValue().toString(16) : 'XX') +
-					   '.' + (this.av3c.level_id ? this.av3c.level_id.getValue().toString(16) : 'XX');
+	return baseCodec + '.' + (this.av3c.profile_id ? this.av3c.profile_id.get().toString(16) : 'XX') +
+					   '.' + (this.av3c.level_id ? this.av3c.level_id.get().toString(16) : 'XX');
 }
 
 BoxParser.av3aSampleEntry.prototype.getCodec =
 BoxParser.a3asSampleEntry.prototype.getCodec = function() {
 	var baseCodec = BoxParser.SampleEntry.prototype.getCodec.call(this);
-	return baseCodec + '.' + (this.dca3.audio_codec_id ? this.av3c.audio_codec_id.getValue() : 'X');
+	return baseCodec + '.' + (this.dca3.audio_codec_id ? this.dca3.audio_codec_id.get() : 'X');
 }

--- a/src/box-codecs.js
+++ b/src/box-codecs.js
@@ -266,8 +266,12 @@ BoxParser.av01SampleEntry.prototype.getCodec = function() {
 
 BoxParser.avs3SampleEntry.prototype.getCodec = function() {
 	var baseCodec = BoxParser.SampleEntry.prototype.getCodec.call(this);
-	
-	return baseCodec + '.' + (this.av3c.profile_id ? this.av3c.profile_id.toString(16) : 'XX') +
-					   '.' + (this.av3c.level_id ? this.av3c.level_id.toString(16) : 'XX');
+	return baseCodec + '.' + (this.av3c.profile_id ? this.av3c.profile_id.getValue().toString(16) : 'XX') +
+					   '.' + (this.av3c.level_id ? this.av3c.level_id.getValue().toString(16) : 'XX');
 }
 
+BoxParser.av3aSampleEntry.prototype.getCodec =
+BoxParser.a3asSampleEntry.prototype.getCodec = function() {
+	var baseCodec = BoxParser.SampleEntry.prototype.getCodec.call(this);
+	return baseCodec + '.' + (this.dca3.audio_codec_id ? this.av3c.audio_codec_id.getValue() : 'X');
+}

--- a/src/box-codecs.js
+++ b/src/box-codecs.js
@@ -263,3 +263,11 @@ BoxParser.av01SampleEntry.prototype.getCodec = function() {
 	// TODO need to parse the SH to find color config
 	return baseCodec+"."+this.av1C.seq_profile+"."+level+(this.av1C.seq_tier_0?"H":"M")+"."+bitdepth;//+"."+this.av1C.monochrome+"."+this.av1C.chroma_subsampling_x+""+this.av1C.chroma_subsampling_y+""+this.av1C.chroma_sample_position;
 }
+
+BoxParser.avs3SampleEntry.prototype.getCodec = function() {
+	var baseCodec = BoxParser.SampleEntry.prototype.getCodec.call(this);
+	
+	return baseCodec + '.' + (this.av3c.profile_id ? this.av3c.profile_id.toString(16) : 'XX') +
+					   '.' + (this.av3c.level_id ? this.av3c.level_id.toString(16) : 'XX');
+}
+

--- a/src/parsing/AVS-utils.js
+++ b/src/parsing/AVS-utils.js
@@ -243,6 +243,9 @@ phBitBuffer.prototype.skipBits = function(bits) {
         return true;
     }
 };
+phBitBuffer.prototype.skipBit = function() {
+    return this.skipBits(1);
+}
 
 phBitBuffer.prototype.getUE = function() {
     // read in an unsigned Exp-Golomb code;

--- a/src/parsing/AVS-utils.js
+++ b/src/parsing/AVS-utils.js
@@ -1,0 +1,262 @@
+/*
+* Copyright (c) 2024. Paul Higgs
+* License: BSD-3-Clause (see LICENSE file)
+*/
+
+function HexadecimalValue(value, description) {
+    this.value = value;
+    this.description = description === undefined ? null : description;
+}
+HexadecimalValue.prototype.toString = function() {
+    return "0x" + this.value.toString(16) + 
+           (this.description ? " (" + this.description + ")" : "");
+}
+HexadecimalValue.prototype.getValue = function() {
+    return this.value;
+}
+
+
+function BinaryValue(value, bits) {
+    this.value = value;
+    this.bits = bits;
+}
+BinaryValue.prototype.toString = function() {
+    var i, res = "b";
+    for (i=this.bits; i>0; i--)
+        res += (this.value & (1 << (i-1)) ? "1" : "0");
+    return res;
+};
+
+function DescribedValue(value, descriptionFunc) {
+    this.value = value;
+    this.description = (typeof descriptionFunc == "function") ? descriptionFunc(value) : null;
+}
+DescribedValue.prototype.toString = function() {
+    return this.value + (this.description ? " (" + this.description + ")" : "");
+}
+
+
+/**
+ * reads bits and bytes from a buffer that may not contain aligned values
+ */
+function phBitBuffer(stream) {
+    var isLocalBigEndian = function () {
+        var buf = new ArrayBuffer(4);
+        var u32data = new Uint32Array(buf);
+        var u8data = new Uint8Array(buf);
+        u32data[0] = 0xcafebabe;
+        return u8data[0] === 0xca;
+    };
+    var OSisLittleEndian = !isLocalBigEndian();
+    var _buffer = [];
+    var _buffer_size = 0;
+
+    if (stream != undefined) {
+        var stream_length = stream.getLength();
+        var i, buf=[];
+        for (i=0; i<stream_length; i++)
+            buf.push(stream.readUint8());
+        this.load(buf, false);
+    }
+}
+phBitBuffer.prototype.load = function(data, read_only) {
+    this._buffer = data;
+    this._buffer_size = data.length;
+    this._big_endian = true;
+    this._read_error = this._write_error = false;
+
+    this._state={};
+    this._state.read_only = read_only | false;
+    this._state.rbyte = 0;
+    this._state.rbit = 0;
+    this._state.end = this._state.wbyte = this._buffer_size;
+    this._state.wbit = 0;
+};
+phBitBuffer.prototype.getBit = function() {
+    //! Read the next bit and advance the read pointer.
+    if (this._read_error || this.endOfRead()) {
+        this._read_error = true;
+        return 0;
+    }
+    var bit = (this._buffer[this._state.rbyte] >> (this._big_endian ? (7 - this._state.rbit) : this._state.rbit)) & 0x01;
+    if (++this._state.rbit > 7) {
+        this._state.rbyte++;
+        this._state.rbit = 0;
+    }
+    return bit;
+};
+phBitBuffer.prototype.peekBit = function() {
+    //! Read the next bit but don't advance the read pointer.
+    if (this._read_error || this.endOfRead()) {
+        this._read_error = true;
+        return 0;
+    }
+    var bit = (this._buffer[this._state.rbyte] >> (this._big_endian ? (7 - this._state.rbit) : this._state.rbit)) & 0x01;
+    return bit;
+};
+phBitBuffer.prototype.endOfRead =  function() {
+    return this._state.rbyte == this._state.wbyte && this._state.rbit == this._state.wbit;
+};
+phBitBuffer.prototype.getBool = function() {
+    return this.getBit() != 0;
+};
+phBitBuffer.prototype.rdb = function(bytes) {
+    var i, res, ff=0xFFFFFFFFFFFFFFFF;
+    if (this._read_error)
+        return ff;
+    if (this._state.rbit==0) {
+        // Read buffer is byte aligned. Most common case.
+        if (this._state.rbyte + bytes > this._state.wbyte) {
+            // Not enough bytes to read.
+            this._read_error = true;
+            return ff;
+        }
+        else {
+            for (res=0, i=0; i<bytes; i++)
+                res = (res << 8) + this._buffer[this._state.rbyte+i];
+            this._state.rbyte += bytes;
+            return res;
+        }
+    }
+    else {
+        // Read buffer is not byte aligned, use an intermediate aligned buffer.
+        if (this.currentReadBitOffset() + (8 * bytes) > this.currentWriteBitOffset()) {
+            // Not enough bytes to read.
+            this._read_error = true;
+            return ff;
+        }
+        else {
+            for (res=0, i=0; i<bytes; i++) {
+                if (this._big_endian)
+                    res = (res << 8) + ((this._buffer[this._state.rbyte] << this._state.rbit) | (this._buffer[this._state.rbyte + 1] >> (8 - this._state.rbit)));
+                else
+                   res = (res << 8) + ((_buffer[_state.rbyte] >> _state.rbit) | (_buffer[_state.rbyte + 1] << (8 - _state.rbit)));
+                this._state.rbyte++;
+            }
+            return res;
+        }
+    }
+};
+phBitBuffer.prototype.currentReadByteOffset = function() {return this._state.rbyte;};
+phBitBuffer.prototype.currentReadBitOffset = function() {return 8 * this._state.rbyte + this._state.rbit;};
+phBitBuffer.prototype.currentWriteByteOffset = function() {return this._state.wbyte;};
+phBitBuffer.prototype.currentWriteBitOffset = function() {return 8 * this._state.wbyte + this._state.wbit;};
+phBitBuffer.prototype.getUint8 =  function() { return this.rdb(1); };
+
+phBitBuffer.prototype.getUint16 = function() {
+    return this._big_endian ? this.GetUInt16BE(this.rdb(2)) : this.GetUInt16LE(this.rdb(2));
+};
+phBitBuffer.prototype.ByteSwap16 = function(x) { return (x << 8) | (x >> 8); };
+phBitBuffer.prototype.CondByteSwap16BE = function(val) { return this.OSisLittleEndian ? this.ByteSwap16(val) : val; };
+phBitBuffer.prototype.CondByteSwap16LE = function(val) { return this.OSisLittleEndian ? val : this.ByteSwap16(val); };
+phBitBuffer.prototype.GetUInt16BE = function(val) { return this.CondByteSwap16BE(val); };
+phBitBuffer.prototype.GetUInt16LE = function(val) { return this.CondByteSwap16LE(val); };
+
+
+phBitBuffer.prototype.getUint24 = function() { return this._big_endian ? this.GetUInt24BE(this.rdb(3)) : this.GetUInt24LE(this.rdb(3)); };
+phBitBuffer.prototype.ByteSwap24 = function(x) { return ((x & 0xFF0000) >> 16) | (x & 0xFF00) | (x & 0xFF << 16); };
+phBitBuffer.prototype.CondByteSwap24BE = function(val) { return this.OSisLittleEndian ? this.ByteSwap24(val) : val; };
+phBitBuffer.prototype.CondByteSwap24LE = function(val) { return this.OSisLittleEndian ? val : this.ByteSwap24(val); };
+phBitBuffer.prototype.GetUInt24BE = function(val) { return this.CondByteSwap24BE(val); };
+phBitBuffer.prototype.GetUInt24LE =function(val) { return this.CondByteSwap24LE(val); };
+
+phBitBuffer.prototype.getUint32 = function() { return this._big_endian ? this.GetUInt32BE(this.rdb(4)) : this.GetUInt32LE(this.rdb(4)); };
+phBitBuffer.prototype.ByteSwap32 = function(x) { return (x << 24) | ((x << 8) & 0x00FF0000) | ((x >> 8) & 0x0000FF00) | (x >> 24); };
+phBitBuffer.prototype.CondByteSwap32BE = function(val) { return this.OSisLittleEndian ? this.ByteSwap32(val) : val; };
+phBitBuffer.prototype.CondByteSwap32LE = function(val) { return this.OSisLittleEndian ? val : this.ByteSwap32(val); };
+phBitBuffer.prototype.GetUInt32BE = function(val) { return this.CondByteSwap32BE(val); };
+phBitBuffer.prototype.GetUInt32LE =function(val) { return this.CondByteSwap32LE(val); };
+      
+phBitBuffer.prototype.getBits = function(bits) {
+    // No read if read error is already set or not enough bits to read.
+    if (this._read_error || this.currentReadBitOffset() + bits > this.currentWriteBitOffset()) {
+        this._read_error = true;
+        return 0;
+    }
+    var val = 0;
+    if (this._big_endian) {
+        // Read leading bits up to byte boundary
+        while (bits > 0 && this._state.rbit != 0) {
+            val = (val << 1) | this.getBit();
+            --bits;
+        }
+
+        // Read complete bytes
+        while (bits > 7) {
+            val = (val << 8) | this._buffer[this._state.rbyte++];
+                bits -= 8;
+        }
+
+        // Read trailing bits
+        while (bits > 0) {
+            val = (val << 1) | this.getBit();
+            --bits;
+        }
+    }
+    else {
+        // Little endian decoding
+        var shift = 0;
+
+        // Read leading bits up to byte boundary
+        while (bits > 0 && this._state.rbit != 0) {
+            val |= (this.getBit() << shift);
+            --bits;
+            shift++;
+        }
+
+        // Read complete bytes
+        while (bits > 7) {
+            val |= this._buffer[this._state.rbyte++] << shift;
+            bits -= 8;
+            shift += 8;
+        }
+
+        // Read trailing bits
+        while (bits > 0) {
+            val |= (this.getBit() << shift);
+            --bits;
+             shift++;
+        }
+    }
+    return (val);
+};
+phBitBuffer.prototype.skipBits = function(bits) {
+    if (this._read_error) {
+        // Can't skip bits and bytes if read error is already set.
+        return false;
+    }
+    var rpos = 8 * this._state.rbyte + this._state.rbit + bits;
+    var wpos = 8 * this._state.wbyte + this._state.wbit;
+    if (rpos > wpos) {
+        this._state.rbyte = this._state.wbyte;
+        this._state.rbit = this._state.wbit;
+        this._read_error = true;
+        return false;
+    }
+    else {
+        this._state.rbyte = rpos >> 3;
+        this._state.rbit = rpos & 7;
+        return true;
+    }
+};
+
+phBitBuffer.prototype.getUE = function() {
+    // read in an unsigned Exp-Golomb code;
+
+    if (this.getBit() == 1)
+        return 0;
+    else {
+        var zero_count=1;
+        while (this.peekBit() == 0) {
+            this.getBit();
+            zero_count++;
+        }
+        var tmp_value = this.getBits(zero_count+1);
+        return tmp_value - 1;
+    }
+};
+
+phBitBuffer.prototype.byte_alignment = function() {
+    while ( !this._read_error && this._state.rbit != 0)
+        this.skipBit();
+}

--- a/src/parsing/AVS-utils.js
+++ b/src/parsing/AVS-utils.js
@@ -3,28 +3,29 @@
 * License: BSD-3-Clause (see LICENSE file)
 */
 
-function HexadecimalValue(value, description) {
+function HexadecimalValue(value, descriptionFn) {
     this.value = value;
-    this.description = description === undefined ? null : description;
+    this.description = descriptionFn === undefined ? null : descriptionFn(value);
 }
 HexadecimalValue.prototype.toString = function() {
     return "0x" + this.value.toString(16) + 
            (this.description ? " (" + this.description + ")" : "");
 }
-HexadecimalValue.prototype.getValue = function() {
+HexadecimalValue.prototype.get = function() {
     return this.value;
 }
 
 
-function BinaryValue(value, bits) {
+function BinaryValue(value, bits, descriptionFn) {
     this.value = value;
     this.bits = bits;
+    this.description = descriptionFn === undefined ? null : descriptionFn(value);
 }
 BinaryValue.prototype.toString = function() {
     var i, res = "b";
     for (i=this.bits; i>0; i--)
         res += (this.value & (1 << (i-1)) ? "1" : "0");
-    return res;
+    return res + (this.description ? " (" + this.description + ")" : "");
 };
 
 function DescribedValue(value, descriptionFunc) {
@@ -33,6 +34,9 @@ function DescribedValue(value, descriptionFunc) {
 }
 DescribedValue.prototype.toString = function() {
     return this.value + (this.description ? " (" + this.description + ")" : "");
+}
+DescribedValue.prototype.get = function() {
+    return this.value;
 }
 
 
@@ -45,11 +49,11 @@ function phBitBuffer(stream) {
         var u32data = new Uint32Array(buf);
         var u8data = new Uint8Array(buf);
         u32data[0] = 0xcafebabe;
-        return u8data[0] === 0xca;
+        return u8data[3] === 0xca;
     };
-    var OSisLittleEndian = !isLocalBigEndian();
-    var _buffer = [];
-    var _buffer_size = 0;
+    this.OSisLittleEndian = !isLocalBigEndian();
+    this._buffer = [];
+    this._buffer_size = 0;
 
     if (stream != undefined) {
         var stream_length = stream.getLength();

--- a/src/parsing/av3C.js
+++ b/src/parsing/av3C.js
@@ -1,0 +1,554 @@
+/*
+* Copyright (c) 2024. Paul Higgs
+* License: BSD-3-Clause (see LICENSE file)
+*/
+
+function ReferencePictureSet(list, set) {
+    this.list = list;
+    this.set = set;
+    this.pics = [];
+}
+ReferencePictureSet.prototype.set_reference_to_library_enable_flag = function(flag) {
+    this.reference_to_library_enable_flag = flag;
+};
+ReferencePictureSet.prototype.push = function(pic) {
+    this.pics.push(pic);
+};
+ReferencePictureSet.prototype.toString = function() {
+    var ret = "{";
+    if (this.hasOwnProperty("reference_to_library_enable_flag")) 
+        ret += "reference_to_library_enable_flag: " + this.reference_to_library_enable_flag;
+    this.pics.forEach(function write(e) {
+        var str = JSON.stringify(e).replace(/\"/g, "");
+        ret += (ret.length > 3 ? ", " : "") + str;
+    });
+    ret += "}";
+    return ret;
+};
+
+function ReferencePictureList(list) {
+    this.list = list;
+    this.sets = [];
+}
+ReferencePictureList.prototype.push = function(set) {
+    this.sets.push(set);
+};
+ReferencePictureList.prototype.toString = function() {
+    var l = [];
+    this.sets.forEach( function(set) {
+        l.push(set.toString());
+    });
+    return l.join(", ");
+};
+
+function BinaryValue(value, bits) {
+    this.value = value;
+    this.bits = bits;
+}
+BinaryValue.prototype.toString = function() {
+    var i, res = "b";
+    for (i=this.bits; i>0; i--)
+        res += (this.value & (1 << (i-1)) ? "1" : "0");
+    return res;
+};
+
+function WeightQuantMatrix( buffer ) {
+    this.WeightQuantMatrix4x4 = [];
+    this.WeightQuantMatrix8x8 = [];
+
+    for (var sizeId=0; sizeId < 2; sizeId++) {
+        var this_size=[];
+        var WQMSize = 1<<(sizeId+2);
+        for (var i=0; i<WQMSize; i++) {
+            var iVal=[];
+            for (var j=0; j<WQMSize; j++) 
+                iVal.push(buffer.getUE());
+            this_size.push(iVal);
+        }
+        if (sizeId==0)
+            this.WeightQuantMatrix4x4 = this_size;
+        else 
+            this.WeightQuantMatrix8x8 = this_size;
+    }
+}
+WeightQuantMatrix.prototype.toString = function() {
+    var str="";
+    if (this.WeightQuantMatrix4x4.length)
+        str+="4x4: " + JSON.stringify(this.WeightQuantMatrix4x4);
+    if (this.WeightQuantMatrix8x8.length)
+        str += (str.length>2 ? ",\n" : "") + "8x8: " + JSON.stringify(this.WeightQuantMatrix8x8);
+    return str;
+};
+
+// AVS3 configuration box
+BoxParser.createBoxCtor("av3c", function(stream) {
+
+    var isLocalBigEndian = function () {
+        var buf = new ArrayBuffer(4);
+        var u32data = new Uint32Array(buf);
+        var u8data = new Uint8Array(buf);
+        u32data[0] = 0xcafebabe;
+        return u8data[0] === 0xca;
+    };
+
+    var BitBuffer = {
+        /**
+         * reads bits and bytes from a buffer that may not contain aligned values
+         */
+
+        OSisLittleEndian: !isLocalBigEndian(),
+        _buffer: [],
+        _buffer_size: 0,
+
+        load: function(data, read_only) {
+            this._buffer = data;
+            this._buffer_size = data.length;
+            this._big_endian = true;
+            this._read_error = this._write_error = false;
+
+            this._state={};
+            this._state.read_only = read_only | false;
+            this._state.rbyte = 0;
+            this._state.rbit = 0;
+            this._state.end = this._state.wbyte = this._buffer_size;
+            this._state.wbit = 0;
+        },
+        getBit: function() {
+            //! Read the next bit and advance the read pointer.
+            if (this._read_error || this.endOfRead()) {
+                this._read_error = true;
+                return 0;
+            }
+            var bit = (this._buffer[this._state.rbyte] >> (this._big_endian ? (7 - this._state.rbit) : this._state.rbit)) & 0x01;
+            if (++this._state.rbit > 7) {
+                this._state.rbyte++;
+                this._state.rbit = 0;
+            }
+            return bit;
+        },
+        peekBit: function() {
+            //! Read the next bit but don't advance the read pointer.
+            if (this._read_error || this.endOfRead()) {
+                this._read_error = true;
+                return 0;
+            }
+            var bit = (this._buffer[this._state.rbyte] >> (this._big_endian ? (7 - this._state.rbit) : this._state.rbit)) & 0x01;
+            return bit;
+        },
+        endOfRead: function() {
+            return this._state.rbyte == this._state.wbyte && this._state.rbit == this._state.wbit;
+        },
+        getBool: function() {
+            return this.getBit() != 0;
+        },
+        rdb: function(bytes) {
+            var i, res, ff=0xFFFFFFFFFFFFFFFF;
+            if (this._read_error)
+                return ff;
+            if (this._state.rbit==0) {
+                // Read buffer is byte aligned. Most common case.
+                if (this._state.rbyte + bytes > this._state.wbyte) {
+                    // Not enough bytes to read.
+                    this._read_error = true;
+                    return ff;
+                }
+                else {
+                    for (res=0, i=0; i<bytes; i++)
+                        res = (res << 8) + this._buffer[this._state.rbyte+i];
+                    this._state.rbyte += bytes;
+                    return res;
+                }
+            }
+            else {
+                // Read buffer is not byte aligned, use an intermediate aligned buffer.
+                if (this.currentReadBitOffset() + (8 * bytes) > this.currentWriteBitOffset()) {
+                    // Not enough bytes to read.
+                    this._read_error = true;
+                    return ff;
+                }
+                else {
+                    for (res=0, i=0; i<bytes; i++) {
+                        if (this._big_endian)
+                            res = (res << 8) + ((this._buffer[this._state.rbyte] << this._state.rbit) | (this._buffer[this._state.rbyte + 1] >> (8 - this._state.rbit)));
+                        else
+                           res = (res << 8) + ((_buffer[_state.rbyte] >> _state.rbit) | (_buffer[_state.rbyte + 1] << (8 - _state.rbit)));
+                        this._state.rbyte++;
+                    }
+                    return res;
+                }
+            }
+        },
+        currentReadByteOffset: function() {return this._state.rbyte;},
+        currentReadBitOffset: function() {return 8 * this._state.rbyte + this._state.rbit;},
+        currentWriteByteOffset: function() {return this._state.wbyte;},
+        currentWriteBitOffset: function() {return 8 * this._state.wbyte + this._state.wbit;},
+
+        getUint8: function() {
+            return this.rdb(1);
+        },
+
+        getUint16: function() {
+            return this._big_endian ? this.GetUInt16BE(this.rdb(2)) : this.GetUInt16LE(this.rdb(2));
+        },
+        ByteSwap16: function(x) {
+             return (x << 8) | (x >> 8);
+        },
+        CondByteSwap16BE: function(val) {
+            return this.OSisLittleEndian ? this.ByteSwap16(val) : val;
+        },
+        CondByteSwap16LE: function(val) {
+            return this.OSisLittleEndian ? val : this.ByteSwap16(val);
+        },
+        GetUInt16BE: function(val) {
+            return this.CondByteSwap16BE(val);
+        },
+        GetUInt16LE: function(val) {
+            return this.CondByteSwap16LE(val);
+        },
+        
+        getUint32: function() {
+            return this._big_endian ? this.GetUInt32BE(this.rdb(4)) : this.GetUInt32LE(this.rdb(4));
+        },
+        ByteSwap32: function(x) {
+            return (x << 24) | ((x << 8) & 0x00FF0000) | ((x >> 8) & 0x0000FF00) | (x >> 24);
+        },
+        CondByteSwap32BE: function(val) {
+            return this.OSisLittleEndian ? this.ByteSwap32(val) : val;
+        },
+        CondByteSwap32LE: function(val) {
+            return this.OSisLittleEndian ? val : this.ByteSwap32(val);
+        },
+        GetUInt32BE: function(val) {
+            return this.CondByteSwap32BE(val);
+        },
+        GetUInt32LE: function(val) {
+            return this.CondByteSwap32LE(val);
+        },
+              
+        getBits: function(bits) {
+            // No read if read error is already set or not enough bits to read.
+            if (this._read_error || this.currentReadBitOffset() + bits > this.currentWriteBitOffset()) {
+                this._read_error = true;
+                return 0;
+            }
+            var val = 0;
+            if (this._big_endian) {
+                // Read leading bits up to byte boundary
+                while (bits > 0 && this._state.rbit != 0) {
+                    val = (val << 1) | this.getBit();
+                    --bits;
+                }
+
+                // Read complete bytes
+                while (bits > 7) {
+                    val = (val << 8) | this._buffer[this._state.rbyte++];
+                        bits -= 8;
+                }
+
+                // Read trailing bits
+                while (bits > 0) {
+                    val = (val << 1) | this.getBit();
+                    --bits;
+                }
+            }
+            else {
+                // Little endian decoding
+                var shift = 0;
+
+                // Read leading bits up to byte boundary
+                while (bits > 0 && this._state.rbit != 0) {
+                    val |= (this.getBit() << shift);
+                    --bits;
+                    shift++;
+                }
+
+                // Read complete bytes
+                while (bits > 7) {
+                    val |= this._buffer[this._state.rbyte++] << shift;
+                    bits -= 8;
+                    shift += 8;
+                }
+
+                // Read trailing bits
+                while (bits > 0) {
+                    val |= (this.getBit() << shift);
+                    --bits;
+                     shift++;
+                }
+            }
+            return (val);
+        },
+        skipBits: function(bits) {
+            if (this._read_error) {
+                // Can't skip bits and bytes if read error is already set.
+                return false;
+            }
+            var rpos = 8 * this._state.rbyte + this._state.rbit + bits;
+            var wpos = 8 * this._state.wbyte + this._state.wbit;
+            if (rpos > wpos) {
+                this._state.rbyte = this._state.wbyte;
+                this._state.rbit = this._state.wbit;
+                this._read_error = true;
+                return false;
+            }
+            else {
+                this._state.rbyte = rpos >> 3;
+                this._state.rbit = rpos & 7;
+                return true;
+            }
+        },
+
+        getUE: function() {
+            // read in an unsigned Exp-Golomb code;
+
+            if (this.getBit() == 1)
+                return 0;
+            else {
+                var zero_count=1;
+                while (this.peekBit() == 0) {
+                    this.getBit();
+                    zero_count++;
+                }
+                var tmp_value = this.getBits(zero_count+1);
+                return tmp_value - 1;
+            }
+        }
+    };
+
+    var MAIN_8 = 0x20, MAIN_10 = 0x22, HIGH_8 = 0x30, HIGH_10 = 0x32;
+
+    var se2value = function (codeNum) {
+        return (Math.pow(-1, codeNum+1) * Math.ceil(codeNum/2));
+    };
+    this.configurationVersion = stream.readUint8();
+    if (this.configurationVersion != 1) {
+        Log.error("av3c version "+this.configurationVersion+" not supported");
+        return;
+    }
+    var sequence_header_length = stream.readUint16();
+
+    var i, j, buf=[];
+    for (i=0; i<sequence_header_length; i++) {
+        buf.push(stream.readUint8());
+    }
+    BitBuffer.load(buf, false);
+
+    tmp_byte = BitBuffer.getUint32();   // video_sequence_start_code
+    this.profile_id = BitBuffer.getUint8();
+    this.level_id = BitBuffer.getUint8();
+    this.progressive_sequence = BitBuffer.getBit();
+    this.field_coded_sequence = BitBuffer.getBit();
+    this.library_stream_flag = BitBuffer.getBit();
+    if (!this.library_stream_flag) {
+        this.library_picture_enable_flag = BitBuffer.getBit();
+        if (this.library_picture_enable_flag)
+            this.duplicate_sequence_number_flag = BitBuffer.getBit();
+    }
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.horizontal_size = BitBuffer.getBits(14);
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.vertical_size = BitBuffer.getBits(14);
+    this.chroma_format = new BinaryValue(BitBuffer.getBits(2), 2);
+    this.sample_precision = new BinaryValue(BitBuffer.getBits(3), 3);
+    
+    if (this.profile_id == MAIN_10 || this.profile_id == HIGH_10)
+        this.encoding_precision = new BinaryValue(BitBuffer.getBits(3), 3);
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.aspect_ratio = new BinaryValue(BitBuffer.getBits(4), 4);
+    this.frame_rate_code = new BinaryValue(BitBuffer.getBits(4), 4);
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.bit_rate_lower = BitBuffer.getBits(18);
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.bit_rate_upper = BitBuffer.getBits(12);
+    this.low_delay = BitBuffer.getBit();
+    this.temporal_id_enable_flag = BitBuffer.getBit();
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.bbv_buffer_size = BitBuffer.getBits(18);
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.max_dpb_minus1 = BitBuffer.getBits(4);
+    this.rpl1_index_exist_flag = BitBuffer.getBit();
+    this.rpl1_same_as_rpl0_flag = BitBuffer.getBit();
+    BitBuffer.skipBits(1);  // marker_bit
+
+    var reference_picture_list = function(list, rpls) {
+        var this_set = new ReferencePictureSet(list, rpls);
+        if (this.library_picture_enable_flag)
+        this_set.set_reference_to_library_enable_flag(BitBuffer.getBit());
+        var num_of_ref_pic = BitBuffer.getUE();
+        for (var i2=0; i2<num_of_ref_pic; i2++) {
+            var this_pic = {}, LibraryIndexFlag = false;     
+            if (this.reference_to_library_enable_flag)
+                LibraryIndexFlag = this_pic.library_index_flag = BitBuffer.getBit();
+            if (LibraryIndexFlag)
+                this_pic.referenced_library_picture_index = BitBuffer.getUE();
+            else {
+                this_pic.abs_delta_doi = BitBuffer.getUE();
+                if (this_pic.abs_delta_doi > 0)
+                    this_pic.sign_delta_doi = BitBuffer.getBit();
+            }
+            this_set.push(this_pic);
+        }
+        return this_set;
+    };
+
+    this.num_ref_pic_list_set0 = BitBuffer.getUE();
+    this.rpl0 = new ReferencePictureList(0);
+    for (j=0; j<this.num_ref_pic_list_set0; j++)
+        this.rpl0.push(reference_picture_list(0, j));
+
+    if (!this.rpl1_same_as_rpl0_flag) {
+        this.num_ref_pic_list_set1 = BitBuffer.getUE();
+        this.rpl1 = new ReferencePictureList(1);
+        for (j=0; j<this.num_ref_pic_list_set1; j++)
+            this.rpl1.push(reference_picture_list(1, j));
+    }
+
+    this.num_ref_default_active_minus1_0 = BitBuffer.getUE();
+    this.num_ref_default_active_minus1_1 = BitBuffer.getUE();
+    this.log2_lcu_size_minus2 = BitBuffer.getBits(3);
+    this.log2_min_cu_size_minus2 = BitBuffer.getBits(2);
+    this.log2_max_part_ratio_minus2 = BitBuffer.getBits(2);
+    this.max_split_times_minus6 = BitBuffer.getBits(3);
+    this.log2_min_qt_size_minus2 = BitBuffer.getBits(3);
+    this.log2_max_bt_size_minus2 = BitBuffer.getBits(3);
+    this.log2_max_eqt_size_minus3 = BitBuffer.getBits(2);
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.weight_quant_enable_flag = BitBuffer.getBit();
+    if (this.weight_quant_enable_flag) {
+        this.load_seq_weight_quant_data_flag = BitBuffer.getBit();
+        if (this.load_seq_weight_quant_data_flag) 
+            this.weight_quant_matrix = new WeightQuantMatrix(BitBuffer);
+    }
+
+    this.st_enable_flag = BitBuffer.getBit();
+    this.sao_enable_flag = BitBuffer.getBit();
+    this.alf_enable_flag = BitBuffer.getBit();
+    this.affine_enable_flag = BitBuffer.getBit();
+    this.smvd_enable_flag = BitBuffer.getBit();
+    this.ipcm_enable_flag = BitBuffer.getBit();
+    this.amvr_enable_flag = BitBuffer.getBit();
+    this.num_of_hmvp_cand = BitBuffer.getBits(4);
+    this.umve_enable_flag = BitBuffer.getBit();
+    this.st_enable_flag = BitBuffer.getBit();
+    this.st_enable_flag = BitBuffer.getBit();
+    if (this.num_of_hmvp_cand != 0 && this.amvr_enable_flag)
+        this.emvr_enable_flag = BitBuffer.getBit();
+    this.intra_pf_enable_flag = BitBuffer.getBit();
+    this.tscpm_enable_flag = BitBuffer.getBit();
+    BitBuffer.skipBits(1);  // marker_bit
+
+    this.dt_enable_flag = BitBuffer.getBit();
+    if (this.dt_enable_flag)
+        this.log2_max_dt_size_minus4 = BitBuffer.getBits(2);
+    this.pbt_enable_flag = BitBuffer.getBit(); 
+
+    if (this.profile_id == MAIN_10 || this.profile_id == HIGH_10) {
+        this.pmc_enable_flag = BitBuffer.getBit();
+        this.iip_enable_flag = BitBuffer.getBit();
+        this.sawp_enable_flag = BitBuffer.getBit();
+        if (this.affine_enable_flag)
+            this.asr_enable_flag = BitBuffer.getBit();
+        this.awp_enable_flag = BitBuffer.getBit();
+        this.etmvp_mvap_enable_flag = BitBuffer.getBit();
+        this.dmvr_enable_flag = BitBuffer.getBit();
+        this.bio_enable_flag = BitBuffer.getBit();
+        this.bgc_enable_flag = BitBuffer.getBit();
+        this.inter_pf_enable_flag = BitBuffer.getBit();
+        this.inter_pfc_enable_flag = BitBuffer.getBit();
+        this.obmc_enable_flag = BitBuffer.getBit();
+
+        this.sbt_enable_flag = BitBuffer.getBit();
+        this.ist_enable_flag = BitBuffer.getBit();
+
+        this.esao_enable_flag = BitBuffer.getBit();
+        this.ccsao_enable_flag = BitBuffer.getBit();
+        if (this.alf_enable_flag)
+            this.ealf_enable_flag = BitBuffer.getBit();
+        this.ibc_enable_flag = BitBuffer.getBit();
+        BitBuffer.skipBits(1);  // marker_bit
+
+        this.isc_enable_flag = BitBuffer.getBit();
+        if (this.ibc_enable_flag || this.isc_enable_flag)
+            this.num_of_intra_hmvp_cand = BitBuffer.getBits(4);
+        this.fimc_enable_flag = BitBuffer.getBit();
+        this.nn_tools_set_hook = BitBuffer.getBits(8);
+        if (this.nn_tools_set_hook & 0x01)
+            this.num_of_nn_filter_minus1 = BitBuffer.getUE();
+        BitBuffer.skipBits(1);  // marker_bit
+    }
+    if (this.low_delay == 0)
+        this.output_reorder_delay = BitBuffer.getBits(5);
+    this.cross_patch_loop_filter_enable_flag = BitBuffer.getBit();
+    this.ref_colocated_patch_flag = BitBuffer.getBit();
+    this.stable_patch_flag = BitBuffer.getBit();
+    if (this.stable_patch_flag) {
+        this.uniform_patch_flag = BitBuffer.getBit();
+        if (this.uniform_patch_flag) {
+            BitBuffer.skipBits(1);  // marker_bit
+            this.patch_width_minus1 = BitBuffer.getUE();
+            this.patch_height_minus1 = BitBuffer.getUE();
+        }
+    }
+    BitBuffer.skipBits(2);  // reserved bits
+
+    this.library_dependency_idc = new BinaryValue(stream.readUint8(), 2);
+});
+
+
+
+function AVS3TemporalLayer(_temporal_layer_id, _frame_rate_code, _temporal_bit_rate_lower, _temporal_bit_rate_upper) {
+    this.temporal_layer_id = _temporal_layer_id;
+    this.frame_rate_code = new BinaryValue(_frame_rate_code, 3);
+    this.temporal_bit_rate_lower = _temporal_bit_rate_lower;
+    this.temporal_bit_rate_upper = _temporal_bit_rate_upper;
+}
+AVS3TemporalLayer.prototype.toString = function() {
+    return "{temporal_layer_id:" + this.temporal_layer_id +
+                ", frame_rate_code:" + this.frame_rate_code.toString() +
+                ", temporal_bit_rate_lower:" + this.temporal_bit_rate_lower +
+                ", temporal_bit_rate_upper:" + this.temporal_bit_rate_upper + "}";
+};
+
+function AVS3TemporalLayers(noarg) {
+    this.layers = [];
+}
+AVS3TemporalLayers.prototype.push = function(layer) {
+    this.layers.push(layer);
+};
+AVS3TemporalLayers.prototype.toString = function() {
+    var l = [];
+    this.layers.forEach( function(layer) {
+        l.push(layer.toString);
+    });
+    return l.join(", ");
+};
+
+
+// LAVS3 configuration box (layered AVS3 video)
+BoxParser.createBoxCtor("lavc", function(stream) {
+    this.configurationVersion = stream.readUint8();
+    if (this.configurationVersion != 1) {
+        Log.error("lavc version "+this.configurationVersion+" not supported");
+        return;
+    }
+    this.numTemporalLayers = stream.readUint8();
+    this.layers=new AVS3TemporalLayers();
+    for (var i=0; i<this.num_temporal_layers; i++) {
+        var tmp_val1 = stream.readUint8();
+        var tmp_val2 = stream.readUint32();
+
+        this.layers.push(new AVS3TemporalLayer(
+            (tmp_val1 >> 5) & 0x07,
+            (tmp_val1 >> 1) & 0x0f,
+            (tmp_val2 >> 14) & 0x0003ffff,
+            (tmp_val2 >> 2) & 0x00000fff) );
+    }
+});

--- a/src/parsing/av3a.js
+++ b/src/parsing/av3a.js
@@ -345,7 +345,7 @@ function parseAvs3AudioLLSpecificConfig(BitBuffer) {
         for (var i=0; i<addition_info_length; i++)
             this.data.addition_info.push(BitBuffer.getUint8());
     }
-
+    BitBuffer.skipBits(2); // reserved
     
 }
 parseAvs3AudioLLSpecificConfig.prototype.toHTML = function() {

--- a/src/parsing/av3a.js
+++ b/src/parsing/av3a.js
@@ -88,7 +88,7 @@ function parseCA3SpecificBox(BitBuffer) {
         case 2:
             // Avs3AudioGASpecificConfig()
             this.data.sampling_frequency_index = BitBuffer.getBits(4);
-            this.data.nn_type = BitBuffer.getBits(3);
+            this.data.nn_type = new DescribedValue(BitBuffer.getBits(3), AVS3nntype);
             BitBuffer.skipBits(1);
             this.data.content_type = BitBuffer.getBits(4);
             if (this.data.content_type == 0) {
@@ -113,18 +113,18 @@ function parseCA3SpecificBox(BitBuffer) {
                 this.data.hoa_order = BitBuffer.getBits(4);
             }
             this.data.total_bitrate = BitBuffer.getUint16()
-            this.data.resolution = BitBuffer.getBits(2);
+            this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
             break;
         case 0:
             // Avs3AudioGHSpecificConfig()
             this.data.sampling_frequency_index = BitBuffer.getBits(4);
             this.data.anc_data_index = BitBuffer.getBool();
-            this.data.coding_profile = BitBuffer.getBits(3);
+            this.data.coding_profile = new DescribedValue(BitBuffer.getBits(3), AVS3codingprofile);
             this.data.bitstream_type = BitBuffer.getBit();
             this.data.channel_number_index = BitBuffer.getBits(7);
             this.data.bitrate_index = BitBuffer.getBits(4);
             this.data.raw_frame_length = BitBuffer.getUint16();
-            this.data.resolution = BitBuffer.getBits(2);
+            this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
             var addition_info_length1 = BitBuffer.getUint16();
             if (addition_info_length1 > 0) {
                 this.data.addition_info = [];
@@ -138,9 +138,9 @@ function parseCA3SpecificBox(BitBuffer) {
             if (this.data.sampling_frequency_index == 0xF)
                 this.data.sampling_frequency = BitBuffer.getUint24();
             this.data.anc_data_index = BitBuffer.getBool();
-            this.data.coding_profile = BitBuffer.getBits(3);
+            this.data.coding_profile = new DescribedValue(BitBuffer.getBits(3), AVS3codingprofile);
             this.data.channel_number = BitBuffer.getUint8();
-            this.data.resolution = BitBuffer.getBits(2);
+            this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
             var addition_info_length2 = BitBuffer.getUint16();
             if (addition_info_length2 > 0) {
                 this.data.addition_info = [];
@@ -198,11 +198,13 @@ var AVS3codingprofile = function(val) {
     }
     return "reserved";
 }
-
+var MakeFourCC = function(val) {
+    return String.fromCharCode(val >> 24, (val & 0x00ff0000) >> 16, (val & 0x0000ff00) >> 8, val & 0x000000ff);
+}
 
 function parseAASFHeader(BitBuffer) {
     this.data = {};
-    this.data.aasf_id = BitBuffer.getUint32();
+    this.data.aasf_id = new DescribedValue(BitBuffer.getUint32(), MakeFourCC);
     this.data.header_size = BitBuffer.getUint24();
     this.data.raw_stream_length = BitBuffer.getUint32();
     this.data.audio_codec_id = BitBuffer.getBits(4);
@@ -219,10 +221,10 @@ function parseAASFHeader(BitBuffer) {
             this.data.channel_number = 16 + BitBuffer.getBits(4);
     }
     if (this.data.audio_codec_id == 2) {
-        if (this.data.coding_profile == 0) {
+        if (this.data.coding_profile.get() == 0) {
             this.data.channel_number_index = BitBuffer.getBits(7);
         }
-        if (this.data.coding_profile == 1) {
+        if (this.data.coding_profile.get() == 1) {
             this.data.soundBedType = BitBuffer.getBits(2);
             if (this.data.soundBedType == 0) {
                 this.data.object_channel_number = BitBuffer.getBits(7);
@@ -235,17 +237,17 @@ function parseAASFHeader(BitBuffer) {
                 this.data.bitrate_index_per_channel = BitBuffer.getBits(4);
             }
         }
-        if (this.data.coding_profile == 2) {
+        if (this.data.coding_profile.get() == 2) {
             this.data.order = BitBuffer.getBits(7);
         }
     }
     this.data.sampling_frequency_index = BitBuffer.getBits(4);
-    if (this.data.coding_profile == 1) {
+    if (this.data.coding_profile.get() == 1) {
         if (this.data.sampling_frequency_index == 0xf) {
             this.data.sampling_frequency = BitBuffer.getUint24();
         }
     }
-    if (this.data.audio_codec_id == 0 || (this.data.audio_codec_id ==2 && this.data.coding_profile != 1)) {
+    if (this.data.audio_codec_id == 0 || (this.data.audio_codec_id ==2 && this.data.coding_profile.get() != 1)) {
         this.data.bitrate_index = BitBuffer.getBits(4);
     }
     if (this.data.audio_codec_id == 0) {
@@ -320,7 +322,7 @@ function parseAvs3AudioGHSpecificConfig(BitBuffer) {
     this.data.raw_frame_length = BitBuffer.getUint16();
     this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
     var addition_info_length = BitBuffer.getUint16();
-    if (addition_info_length> 0) {
+    if (addition_info_length > 0) {
         this.data.addition_info=[];
         for (var i=0; i<addition_info_length; i++)
             this.data.addition_info.push(BitBuffer.getUint8());
@@ -340,7 +342,7 @@ function parseAvs3AudioLLSpecificConfig(BitBuffer) {
     this.data.channel_number = BitBuffer.getUint8();
     this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
     var addition_info_length = BitBuffer.getUint16();
-    if (addition_info_length> 0) {
+    if (addition_info_length > 0) {
         this.data.addition_info=[];
         for (var i=0; i<addition_info_length; i++)
             this.data.addition_info.push(BitBuffer.getUint8());

--- a/src/parsing/av3a.js
+++ b/src/parsing/av3a.js
@@ -1,0 +1,370 @@
+/*
+* Copyright (c) 2024. Paul Higgs
+* License: BSD-3-Clause (see LICENSE file)
+*/
+
+/*
+//extension metadata is no longer carried in the track information
+
+function ObjectExtensionMetadataBlock(BitBuffer) {
+
+    var BitsInType = function (loudnessType) {
+        if ([0,1,2,3,4,5,6,9].contains(loudnessType))
+            return 8;
+        else if (loudnessType == 7)
+            return 5;
+        else if (loudnessType == 8)
+            return 2;
+        return 0;
+    }
+    this.loudnessValDef = BitBuffer.getBits(4);
+    this.loudnessVal = BitBuffer.getBits(BitsInType(this.loudnessValDef));
+}
+
+function ObjectExtensionMetadataBlock(BitBuffer) {
+    this.maxObjChannelNum = BitBuffer.getUint8();
+    var hasObjChannelLock = BitBuffer.getBool();
+    if (hasObjChannelLock)
+        this.objChannelLock_maxDist = BitBuffer.getBits(4);
+    this.objDiffuse = BitBuffer.getBits(7);
+    this.objGain = BitBuffer.getUint8();
+    this.objDivergence = BitBuffer.getBits(4);
+    if (this.objDivergence > 0)
+        this.objDivergencePosRange = BitBuffer.getBits(4);
+    BitBuffer.byte_alignment();
+}
+
+function LoudnessMetadataBlock(BitBuffer) {
+    var hasSamplePeakLevel = BitBuffer.getBool();
+    BitBuffer.skipBits(3);
+    if (hasSamplePeakLevel) 
+        this.samplePeakLevel = BitBuffer.getBits(12);
+    this.truePeakLevel = BitBuffer.getBits(12);
+    this.loudnessMeasure = BitBuffer.getBits(4);
+    var loudnessValNum = BitBuffer.getBits(4);
+    if (loudnessValNum > 0) {
+        this.loudnessVal = [];
+        for (var i=0; i<loudnessValNum; i++) {
+            var lv = new LoudnessValue(BitBuffer);
+            this.loudnessVal.push(lv);
+        }
+    }
+    BitBuffer.byte_alignment();
+}
+
+function ANCData(BitBuffer) {
+    this.anc_data_length = BitBuffer.getUint8();
+    this.anc_data_number = BitBuffer.getBits(4);
+    BitBuffer.skopBits(4);
+    this.anc_blocks = [];
+    for (var i=0; i< this.anc_data_number; i++) {
+        var anc_data_type = BitBuffer.getBits(4);
+        switch (anc_data_type) {
+            case 1:
+                var oem = new ObjectExtensionMetadataBlock(BitBuffer);
+                this.anc_blocks.push(oem);
+                break;
+            case 2:
+                var lm = new LoudnessMetadataBlock(BitBuffer);
+                this.and_blocks.push(lm);
+                break;
+        }
+
+    }
+    BitBuffer.byte_alignment(); 
+}
+*/
+
+function AVS3Acodec(codec_id) {
+    var codecs = ["General High Rate", "Lossless", "General Full Rate"];
+    return codec_id + " (" + (codec_id < codecs.length ? codecs[codec_id] : "undefined" ) + ")"
+}
+
+function parseCA3SpecificBox(BitBuffer) {
+    this.data = {};
+    this.data.audio_codec_id  = BitBuffer.getBits(4);
+    this.data.audio_codec_id  = new HexadecimalValue(audio_codec_id, AVS3Acodec(audio_codec_id));
+    switch (this.data.audio_codec_id) {
+        case 2:
+            // Avs3AudioGASpecificConfig()
+            this.data.sampling_frequency_index = BitBuffer.getBits(4);
+            this.data.nn_type = BitBuffer.getBits(3);
+            BitBuffer.skipBits(1);
+            this.data.content_type = BitBuffer.getBits(4);
+            if (this.data.content_type == 0) {
+                // channel based audio
+                this.data.channel_number_index = BitBuffer.getBits(7);
+                BitBuffer.skipBits(1);
+            }
+            else if (this.data.content_type == 1) {
+                // object based audio
+                this.data.num_objects = BitBuffer.getBits(7);
+                BitBuffer.skipBits(1);
+            }
+            else if (this.data.content_type == 2) {
+                // hybrid channel+object based audio
+                this.data.channel_number_index = BitBuffer.getBits(7);
+                BitBuffer.skipBits(1);
+                this.data.num_objects = BitBuffer.getBits(7);
+                BitBuffer.skipBits(1);
+            }
+            else if (this.data.content_type == 3) {
+                // high order ambisonics
+                this.data.hoa_order = BitBuffer.getBits(4);
+            }
+            this.data.total_bitrate = BitBuffer.getUint16()
+            this.data.resolution = BitBuffer.getBits(2);
+            break;
+        case 0:
+            // Avs3AudioGHSpecificConfig()
+            this.data.sampling_frequency_index = BitBuffer.getBits(4);
+            this.data.anc_data_index = BitBuffer.getBool();
+            this.data.coding_profile = BitBuffer.getBits(3);
+            this.data.bitstream_type = BitBuffer.getBit();
+            this.data.channel_number_index = BitBuffer.getBits(7);
+            this.data.bitrate_index = BitBuffer.getBits(4);
+            this.data.raw_frame_length = BitBuffer.getUint16();
+            this.data.resolution = BitBuffer.getBits(2);
+            var addition_info_length1 = BitBuffer.getUint16();
+            if (addition_info_length1 > 0) {
+                this.data.addition_info = [];
+                for (i=0; i<addition_info_length1; i++) 
+                    this.data.addition_info.push(BitBuffer.getUint8());
+            }
+            break;
+        case 1:
+            // Avs3AudioLLSpecificConfig()
+            this.data.sampling_frequency_index = BitBuffer.getBits(4);
+            if (this.data.sampling_frequency_index == 0xF)
+                this.data.sampling_frequency = BitBuffer.getUint24();
+            this.data.anc_data_index = BitBuffer.getBool();
+            this.data.coding_profile = BitBuffer.getBits(3);
+            this.data.channel_number = BitBuffer.getUint8();
+            this.data.resolution = BitBuffer.getBits(2);
+            var addition_info_length2 = BitBuffer.getUint16();
+            if (addition_info_length2 > 0) {
+                this.data.addition_info = [];
+                for (i=0; i<addition_info_length2; i++) 
+                    this.data.addition_info.push(BitBuffer.getUint8());
+            }
+            break;
+    }
+    BitBuffer.byte_alignment();
+}
+
+function tabularize(data) {
+    var res = "<table>";
+    Object.getOwnPropertyNames(this.data).forEach(function (val, idx, array) {
+        var fmt_val = "";
+        if (Array.isArray(arg)) {
+            for (var i = 0; i < val.length; i++) {
+                var hex = val[i].toString(16);
+                html += (hex.length === 1 ? "0"+hex : hex) ;
+                if (i%4 === 3) html += ' ';
+            }
+        }
+        else
+            fmt_val = val;
+        html += "<tr><td><code>" + val + "</code></td><td><code>" + this[val] + "</code></td></tr>";
+    }); 
+    return res + "</table>";
+}
+
+parseCA3SpecificBox.prototype.toHTML = function() {
+    return tabularize(this.data);
+};
+
+
+var AVS3resolution = function(val) {
+    switch (val) {
+        case 0: return "8 bits/sample";
+        case 1: return "16 bits/sample";
+        case 2: return "24 bits/sample";
+    }
+    return "reserved";
+}
+var AVS3nntype = function(val) {
+    switch (val) {
+        case 0: return "basic neural network";
+        case 1: return "low-complexity neural network";
+    }
+    return "reserved";
+}
+var AVS3codingprofile = function(val) {
+    switch (val) {
+        case 0: return "basic framework";
+        case 1: return "object metadata framework";
+        case 2: return "HOA data coding framework";
+    }
+    return "reserved";
+}
+
+
+function parseAASFHeader(BitBuffer) {
+    this.data = {};
+    this.data.aasf_id = BitBuffer.getUint32();
+    this.data.header_size = BitBuffer.getUint24();
+    this.data.raw_stream_length = BitBuffer.getUint32();
+    this.data.audio_codec_id = BitBuffer.getBits(4);
+    this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
+    if (this.data.audio_codec_id == 2) 
+        this.data.nn_type = new DescribedValue(BitBuffer.getBits(3), AVS3nntype);
+    this.data.coding_profile = new DescribedValue(BitBuffer.getBits(3), AVS3codingprofile);
+    this.data.anc_data_index = BitBuffer.getBit();
+    if (this.data.audio_codec_id == 0)
+        this.data.channel_number_index = BitBuffer.getBits(7);
+    if (this.data.audio_codec_id == 1) {
+        this.data.channel_number = BitBuffer.getBits(4); 
+        if (this.data.channel_number == 0xF)
+            this.data.channel_number = 16 + BitBuffer.getBits(4);
+    }
+    if (this.data.audio_codec_id == 2) {
+        if (this.data.coding_profile == 0) {
+            this.data.channel_number_index = BitBuffer.getBits(7);
+        }
+        if (this.data.coding_profile == 1) {
+            this.data.soundBedType = BitBuffer.getBits(2);
+            if (this.data.soundBedType == 0) {
+                this.data.object_channel_number = BitBuffer.getBits(7);
+                this.data.bitrate_index_per_channel = BitBuffer.getBits(4);
+            }
+            else if (this.data.soundBedType == 1) {
+                this.data.channel_number_index = BitBuffer.getBits(7);
+                this.data.bitrate_index = BitBuffer.getBits(4);
+                this.data.object_channel_number = BitBuffer.getBits(7);
+                this.data.bitrate_index_per_channel = BitBuffer.getBits(4);
+            }
+        }
+        if (this.data.coding_profile == 2) {
+            this.data.order = BitBuffer.getBits(7);
+        }
+    }
+    this.data.sampling_frequency_index = BitBuffer.getBits(4);
+    if (this.data.coding_profile == 1) {
+        if (this.data.sampling_frequency_index == 0xf) {
+            this.data.sampling_frequency = BitBuffer.getUint24();
+        }
+    }
+    if (this.data.audio_codec_id == 0 || (this.data.audio_codec_id ==2 && this.data.coding_profile != 1)) {
+        this.data.bitrate_index = BitBuffer.getBits(4);
+    }
+    if (this.data.audio_codec_id == 0) {
+        this.data.bitstream_type = BitBuffer.getBit();
+        if (this.data.channel_number == 2) {
+            this.data.supermode_flag = BitBuffer.getBits(2);
+            this.data.couple_channel_config = BitBuffer.getUint8();
+        }
+        if (this.data.channel_number > 2) {
+            this.data.supermode_flag = BitBuffer.getBits(2);
+            this.data.couple_channel_config = BitBuffer.getUint8();
+            this.data.PCAGroupmodeHeader = BitBuffer.getUint8();
+        }
+    }
+    BitBuffer.byte_alignment();
+}
+parseAASFHeader.prototype.toHTML = function() {
+    return tabularize(this.data);
+};
+
+BoxParser.createBoxCtor("av3a", function(stream) {
+    var BitBuffer = new phBitBuffer(stream);
+    this.config = new parseCA3SpecificBox(BitBuffer);
+});
+
+BoxParser.createBoxCtor("a3as", function(stream) {
+    var BitBuffer = new phBitBuffer(stream);
+    this.config = new parseCA3SpecificBox(BitBuffer);
+    BitBuffer.skipBits(16);   // avs3_as_header_length
+    this.avs3_as_header = new parseAASFHeader(BitBuffer);
+});
+
+
+function parseAvs3AudioGASpecificConfig(BitBuffer) {
+    this.data = {};
+    this.data.sampling_frequency_index = BitBuffer.getBits(4);
+    this.data.nn_type = new DescribedValue(BitBuffer.getBits(3), AVS3nntype);
+    buf.skipBits(1);
+    this.data.content_type = BitBuffer.getBits(4);
+    if (this.data.content_type == 0) {
+        this.data.channel_number_index = BitBuffer.getBits(7);
+        BitBuffer.skipBits(1);
+    }
+    else if (this.data.content_type == 1) {
+        this.data.num_objects = BitBuffer.getBits(7);
+        BitBuffer.skipBits(1);
+    }
+    else if (this.data.content_type == 2) {
+        this.data.channel_number_index = BitBuffer.getBits(7);
+        BitBuffer.skipBits(1);
+        this.data.num_objects = BitBuffer.getBits(7);
+        BitBuffer.skipBits(1);
+    }
+    else if (this.data.content_type == 3) {
+        this.data.hoa_order = BitBuffer.getBits(4);
+    }
+    this.data.total_bitrate = BitBuffer.getUint16();
+    this.data.resolution = BitBuffer.getBits(2);
+}
+parseAvs3AudioGASpecificConfig.prototype.toHTML = function() {
+    return tabularize(this.data);
+};
+
+function parseAvs3AudioGHSpecificConfig(BitBuffer) {
+    this.data = {};
+    this.data.sampling_frequency_index = BitBuffer.getBits(4);
+    this.data.anc_data_index = BitBuffer.getBit();
+    this.data.coding_profile = new DescribedValue(BitBuffer.getBits(3), AVS3codingprofile);
+    this.data.bitstream_type = BitBuffer.getBits(1);
+    this.data.channel_number_index = BitBuffer.getBits(7);
+    this.data.bitrate_index = BitBuffer.getBits(4);
+    this.data.raw_frame_length = BitBuffer.getUint16();
+    this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
+    var addition_info_length = BitBuffer.getUint16();
+    if (addition_info_length> 0) {
+        this.data.addition_info=[];
+        for (var i=0; i<addition_info_length; i++)
+            this.data.addition_info.push(BitBuffer.getUint8());
+    }
+}
+parseAvs3AudioGHSpecificConfig.prototype.toHTML = function() {
+    return tabularize(this.data);
+};
+
+function parseAvs3AudioLLSpecificConfig(BitBuffer) {
+    this.data = {};
+    this.data.sampling_frequency_index = BitBuffer.getBits(4);
+    if (this.data.sampling_frequency_index == 0xF)
+        this.data.sampling_frequency = BitBuffer.getUint24();
+    this.data.anc_data_index = BitBuffer.getBit();
+    this.data.coding_profile = new DescribedValue(BitBuffer.getBits(3), AVS3codingprofile);
+    this.data.channel_number = BitBuffer.getUint8();
+    this.data.resolution = new DescribedValue(BitBuffer.getBits(2), AVS3resolution);
+    var addition_info_length = BitBuffer.getUint16();
+    if (addition_info_length> 0) {
+        this.data.addition_info=[];
+        for (var i=0; i<addition_info_length; i++)
+            this.data.addition_info.push(BitBuffer.getUint8());
+    }
+
+    
+}
+parseAvs3AudioLLSpecificConfig.prototype.toHTML = function() {
+    return tabularize(this.data);
+};
+
+BoxParser.createBoxCtor("dca3", function(stream) {
+    var BitBuffer = new phBitBuffer(stream);
+    this.audio_codec_id = BitBuffer.getBits(4);
+
+    if (this.audio_codec_id == 2) {
+        this.Avs3AudioGAConfig = new parseAvs3AudioGASpecificConfig(BitBuffer);
+    }
+    else if (this.audio_codec_id == 0) {
+        this.Avs3AudioGHConfig = new parseAvs3AudioGHSpecificConfig(BitBuffer);
+    }
+    else if (this.audio_codec_id == 1) {
+        this.Avs3AudioLLConfig = new parseAvs3AudioLLSpecificConfig(BitBuffer);
+    }
+
+    BitBuffer.byte_alignmentment();
+});

--- a/src/parsing/av3c.js
+++ b/src/parsing/av3c.js
@@ -73,18 +73,18 @@ WeightQuantMatrix.prototype.toString = function() {
 };
 
 
-
 // AVS3 video configuration box
 BoxParser.createBoxCtor("av3c", function(stream) {
 
     var BitBuffer = new phBitBuffer();
     var MAIN_8 = 0x20, MAIN_10 = 0x22, HIGH_8 = 0x30, HIGH_10 = 0x32;
+    var RESERVED = "Reserved", FORBIDDEN = "Forbidden";
     var AVS3profiles = [  // Table B.1 of T/AI 109.2
         {profile:MAIN_8,  description:"Main 8 bit"},
         {profile:MAIN_10, description:"Main 10 bit"},
         {profile:HIGH_8,  description:"High 8 bit"},
         {profile:HIGH_10, description:"High 10 bit"},
-        {profile:0x00, description:"Forbidden"},
+        {profile:0x00, description:FORBIDDEN},
     ];
     var AVS3levels = [  // Table B.1 of T/AI 109.2
         {level:0x50, description:"8.0.30"},
@@ -128,7 +128,7 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         {level:0x4A, description:"6.2.120"},
         {level:0x49, description:"6.4.120"},
         {level:0x4B, description:"6.6.120"},
-        {level:0x00, description:"Forbidden"},
+        {level:0x00, description:FORBIDDEN},
     ];
     var AVS3precisions = [  // Table 45 of T/AI 109.2
         {precision: 1, description:"8-bit"},
@@ -151,31 +151,37 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         "300",
         "120/1.001"
     ];
+    var AVS3ratios = [
+        "",
+        "1.0",
+        "4:3",
+        "16:9",
+        "2.21:1"
+    ];
 
     var AVS3profile = function (profile) {
         var t = AVS3profiles.find(function (e) { return e.profile == profile; });
-        return t == undefined ? "Reserved" : t.description;
+        return t == undefined ? RESERVED : t.description;
     };
     var AVS3level = function (level) {
         var t = AVS3levels.find(function (e) { return e.level == level; });
-        return t == undefined ? "Reserved" : t.description;
+        return t == undefined ? RESERVED : t.description;
     };
     var se2value = function (codeNum) {
         return (Math.pow(-1, codeNum+1) * Math.ceil(codeNum/2));
     };
     var AVS3precision = function (precision) {
         var t = AVS3precisions.find(function (e) { return e.precision == precision});
-        return t == undefined ? "Reserved" : t.description;    
+        return t == undefined ? RESERVED : t.description;    
     }
     var AVS3chroma = function (chroma) {
-        return chroma == 1 ? "4:2:0" : "Reserved";
+        return chroma == 1 ? "4:2:0" : RESERVED;
+    }
+    var AVS3aspectratio = function (ratio) {
+        return (ratio == 0) ? FORBIDDEN : ((ratio >= AVS3ratios.length) ? RESERVED : AVS3ratios[ratio]);
     }
     var AVS3framerate = function (framerate) {
-        if (framerate == 0)
-            return "Forbidden";
-        else if (framerate >= 15)
-            return "Reserved";
-        else return AVS3framerates+" fps";
+        return (framerate == 0) ? FORBIDDEN : ((framerate >= AVS3framerates.length) ? RESERVED : AVS3framerates[framerate]+" fps");
     }
 
     this.configurationVersion = stream.readUint8();
@@ -183,12 +189,9 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         Log.error("av3c version "+this.configurationVersion+" not supported");
         return;
     }
-    var sequence_header_length = stream.readUint16();
-
-    var i, j, buf=[];
-    for (i=0; i<sequence_header_length; i++) {
+    var buf=[], sequence_header_length = stream.readUint16();
+    for (var i=0; i<sequence_header_length; i++)
         buf.push(stream.readUint8());
-    }
     BitBuffer.load(buf, false);
 
     this.video_sequence_start_code = new HexadecimalValue(BitBuffer.getUint32());
@@ -202,10 +205,10 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         if (this.library_picture_enable_flag)
             this.duplicate_sequence_number_flag = BitBuffer.getBit();
     }
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.horizontal_size = BitBuffer.getBits(14);
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.vertical_size = BitBuffer.getBits(14);
     this.chroma_format = new BinaryValue(BitBuffer.getBits(2), 2, AVS3chroma);
@@ -213,27 +216,27 @@ BoxParser.createBoxCtor("av3c", function(stream) {
     
     if (this.profile_id.get() == MAIN_10 || this.profile_id.get() == HIGH_10)
         this.encoding_precision = new BinaryValue(BitBuffer.getBits(3), 3, AVS3precision);
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
-    this.aspect_ratio = new BinaryValue(BitBuffer.getBits(4), 4);
-    this.frame_rate_code = new BinaryValue(BitBuffer.getBits(4), 4);
-    BitBuffer.skipBits(1);  // marker_bit
+    this.aspect_ratio = new BinaryValue(BitBuffer.getBits(4), 4, AVS3aspectratio);
+    this.frame_rate_code = new BinaryValue(BitBuffer.getBits(4), 4,AVS3framerate);
+    BitBuffer.skipBit();  // marker_bit
 
     this.bit_rate_lower = BitBuffer.getBits(18);
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.bit_rate_upper = BitBuffer.getBits(12);
     this.low_delay = BitBuffer.getBit();
     this.temporal_id_enable_flag = BitBuffer.getBit();
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.bbv_buffer_size = BitBuffer.getBits(18);
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.max_dpb_minus1 = BitBuffer.getBits(4);
     this.rpl1_index_exist_flag = BitBuffer.getBit();
     this.rpl1_same_as_rpl0_flag = BitBuffer.getBit();
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     var reference_picture_list = function(list, rpls) {
         var this_set = new ReferencePictureSet(list, rpls);
@@ -258,14 +261,14 @@ BoxParser.createBoxCtor("av3c", function(stream) {
 
     this.num_ref_pic_list_set0 = BitBuffer.getUE();
     this.rpl0 = new ReferencePictureList(0);
-    for (j=0; j<this.num_ref_pic_list_set0; j++)
+    for (var j=0; j<this.num_ref_pic_list_set0; j++)
         this.rpl0.push(reference_picture_list(0, j));
 
     if (!this.rpl1_same_as_rpl0_flag) {
         this.num_ref_pic_list_set1 = BitBuffer.getUE();
         this.rpl1 = new ReferencePictureList(1);
-        for (j=0; j<this.num_ref_pic_list_set1; j++)
-            this.rpl1.push(reference_picture_list(1, j));
+        for (var j2=0; j2<this.num_ref_pic_list_set1; j2++)
+            this.rpl1.push(reference_picture_list(1, j2));
     }
 
     this.num_ref_default_active_minus1_0 = BitBuffer.getUE();
@@ -277,7 +280,7 @@ BoxParser.createBoxCtor("av3c", function(stream) {
     this.log2_min_qt_size_minus2 = BitBuffer.getBits(3);
     this.log2_max_bt_size_minus2 = BitBuffer.getBits(3);
     this.log2_max_eqt_size_minus3 = BitBuffer.getBits(2);
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.weight_quant_enable_flag = BitBuffer.getBit();
     if (this.weight_quant_enable_flag) {
@@ -301,7 +304,7 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         this.emvr_enable_flag = BitBuffer.getBit();
     this.intra_pf_enable_flag = BitBuffer.getBit();
     this.tscpm_enable_flag = BitBuffer.getBit();
-    BitBuffer.skipBits(1);  // marker_bit
+    BitBuffer.skipBit();  // marker_bit
 
     this.dt_enable_flag = BitBuffer.getBit();
     if (this.dt_enable_flag)
@@ -331,7 +334,7 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         if (this.alf_enable_flag)
             this.ealf_enable_flag = BitBuffer.getBit();
         this.ibc_enable_flag = BitBuffer.getBit();
-        BitBuffer.skipBits(1);  // marker_bit
+        BitBuffer.skipBit();  // marker_bit
 
         this.isc_enable_flag = BitBuffer.getBit();
         if (this.ibc_enable_flag || this.isc_enable_flag)
@@ -340,7 +343,7 @@ BoxParser.createBoxCtor("av3c", function(stream) {
         this.nn_tools_set_hook = BitBuffer.getBits(8);
         if (this.nn_tools_set_hook & 0x01)
             this.num_of_nn_filter_minus1 = BitBuffer.getUE();
-        BitBuffer.skipBits(1);  // marker_bit
+        BitBuffer.skipBit();  // marker_bit
     }
     if (this.low_delay == 0)
         this.output_reorder_delay = BitBuffer.getBits(5);
@@ -350,7 +353,7 @@ BoxParser.createBoxCtor("av3c", function(stream) {
     if (this.stable_patch_flag) {
         this.uniform_patch_flag = BitBuffer.getBit();
         if (this.uniform_patch_flag) {
-            BitBuffer.skipBits(1);  // marker_bit
+            BitBuffer.skipBit();  // marker_bit
             this.patch_width_minus1 = BitBuffer.getUE();
             this.patch_height_minus1 = BitBuffer.getUE();
         }

--- a/src/parsing/av3c.js
+++ b/src/parsing/av3c.js
@@ -35,6 +35,8 @@ ReferencePictureList.prototype.push = function(set) {
     this.sets.push(set);
 };
 ReferencePictureList.prototype.toString = function() {
+    if (this.sets.length == 0)
+        return "(empty)";
     var l = [];
     this.sets.forEach( function(set) {
         l.push(set.toString());

--- a/src/parsing/lavc.js
+++ b/src/parsing/lavc.js
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2024. Paul Higgs
+* License: BSD-3-Clause (see LICENSE file)
+*/
+
+
+function AVS3TemporalLayer(_temporal_layer_id, _frame_rate_code, _temporal_bit_rate_lower, _temporal_bit_rate_upper) {
+    this.temporal_layer_id = _temporal_layer_id;
+    this.frame_rate_code = new BinaryValue(_frame_rate_code, 3);
+    this.temporal_bit_rate_lower = _temporal_bit_rate_lower;
+    this.temporal_bit_rate_upper = _temporal_bit_rate_upper;
+}
+AVS3TemporalLayer.prototype.toString = function() {
+    return "{temporal_layer_id:" + this.temporal_layer_id +
+                ", frame_rate_code:" + this.frame_rate_code.toString() +
+                ", temporal_bit_rate_lower:" + this.temporal_bit_rate_lower +
+                ", temporal_bit_rate_upper:" + this.temporal_bit_rate_upper + "}";
+};
+
+function AVS3TemporalLayers(noarg) {
+    this.layers = [];
+}
+AVS3TemporalLayers.prototype.push = function(layer) {
+    this.layers.push(layer);
+};
+AVS3TemporalLayers.prototype.toString = function() {
+    var l = [];
+    this.layers.forEach( function(layer) {
+        l.push(layer.toString);
+    });
+    return l.join(", ");
+};
+
+
+// LAVS3 configuration box (layered AVS3 video)
+BoxParser.createBoxCtor("lavc", function(stream) {
+    this.configurationVersion = stream.readUint8();
+    if (this.configurationVersion != 1) {
+        Log.error("lavc version "+this.configurationVersion+" not supported");
+        return;
+    }
+    this.numTemporalLayers = stream.readUint8();
+    this.layers=new AVS3TemporalLayers();
+    for (var i=0; i<this.num_temporal_layers; i++) {
+        var tmp_val1 = stream.readUint8();
+        var tmp_val2 = stream.readUint32();
+
+        this.layers.push(new AVS3TemporalLayer(
+            (tmp_val1 >> 5) & 0x07,
+            (tmp_val1 >> 1) & 0x0f,
+            (tmp_val2 >> 14) & 0x0003ffff,
+            (tmp_val2 >> 2) & 0x00000fff) );
+    }
+});

--- a/src/parsing/sampleentries/sampleentry.js
+++ b/src/parsing/sampleentries/sampleentry.js
@@ -104,6 +104,8 @@ BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mha1");
 BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mha2");
 BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mhm1");
 BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"mhm2");
+BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"av3a");
+BoxParser.createSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_AUDIO, 	"a3as");
 
 // Encrypted sample entries
 BoxParser.createEncryptedSampleEntryCtor(BoxParser.SAMPLE_ENTRY_TYPE_VISUAL, 	"encv");

--- a/test/boxHtmlTable.js
+++ b/test/boxHtmlTable.js
@@ -33,21 +33,25 @@ function generateBoxTable(box, excluded_fields, additional_props, no_header) {
 			html += '<td><code>';
 			html += prop;
 			html += '</code></td>';
-			html += '<td><code>';
+			html += '<td>';
 			if (prop === "data") {
+				html += '<code>';
 				for (var i = 0; i < box[prop].length; i++) {
 					var j = box[prop][i];
 					var hex = j.toString(16);
 					html += (hex.length === 1 ? "0"+hex : hex);
 					if (i%4 === 3) html += ' ';
 				}
+				html += "</code>";
 			} else {
+				if (box[prop].hasOwnProperty("toHTML") && typeof box[prop].toHTML === "function")
+					html += box[prop].toHTML();
 				if (box[prop].hasOwnProperty("toString") && typeof box[prop].toString === "function")
-					html += box[prop].toString();
+					html += '<code>' + box[prop].toString() + "</code>";
 				else
-					html += box[prop];
-			}
-			html += '</code></td>';
+					html += '<code>' + box[prop] + "</code>";
+				}
+			html += '</td>';
 			html += '</tr>';
 		}
 	}


### PR DESCRIPTION
T/AI 109.6 and T/AI 109.7 define the methods for packaging AVS3 video (according to T/AI 109.2) and AVS3 audio (according to T/AI 109.3) in ISO BMFF.

This PR add support for these media codecs.

Specifications are available at https://standards.cn/AVS3_download/en_index.asp
Video bitstreams are available via DVB - https://dvb.org/specifications/verification-validation/avs3-test-content/
Audio bitstreams are in development