### PR TITLE
Fix hvcC box writing using incorrect order of operations

### DIFF
--- a/src/writing/hvcC.js
+++ b/src/writing/hvcC.js
@@ -12,8 +12,8 @@ BoxParser.hvcCBox.prototype.write = function(stream) {
     this.writeHeader(stream);
 
     stream.writeUint8(this.configurationVersion);
-    stream.writeUint8(this.general_profile_space << 6 +
-                      this.general_tier_flag << 5 +
+    stream.writeUint8((this.general_profile_space << 6) +
+                      (this.general_tier_flag << 5) +
                       this.general_profile_idc);
     stream.writeUint32(this.general_profile_compatibility);
     stream.writeUint8Array(this.general_constraint_indicator);


### PR DESCRIPTION
Current code:
```js
stream.writeUint8(this.general_profile_space << 6 +
  this.general_tier_flag << 5 +
  this.general_profile_idc);
```

is equivalent to 

```js
stream.writeUint8(this.general_profile_space << (6 +
  this.general_tier_flag) << (5 +
  this.general_profile_idc));
```

which is incorrect. The correct order of operations are:

```js
stream.writeUint8((this.general_profile_space << 6) +
  (this.general_tier_flag << 5) +
  this.general_profile_idc);
```

This fixes the file segmenter tool producing invalid hvcC boxes for certain kinds of hvc1 video.
