### PR TITLE
implement cslg version 1

### DIFF
--- a/src/parsing/cslg.js
+++ b/src/parsing/cslg.js
@@ -6,6 +6,12 @@ BoxParser.createFullBoxCtor("cslg", function(stream) {
 		this.greatestDecodeToDisplayDelta = stream.readInt32(); /* signed */
 		this.compositionStartTime = stream.readInt32(); /* signed */
 		this.compositionEndTime = stream.readInt32(); /* signed */
+	} else if (this.version === 1) {
+		this.compositionToDTSShift = stream.readInt64(); /* signed */
+		this.leastDecodeToDisplayDelta = stream.readInt64(); /* signed */
+		this.greatestDecodeToDisplayDelta = stream.readInt64(); /* signed */
+		this.compositionStartTime = stream.readInt64(); /* signed */
+		this.compositionEndTime = stream.readInt64(); /* signed */
 	}
 });
 


### PR DESCRIPTION
gstreamer muxing uses version 1 of `cslg`, which is not currently supported.

For the syntax, see ISO/IEC 14496-12:2022 Section 8.6.1.4.