### PR TITLE
Add support for HDR Vivid

### DIFF
--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x, 22.x]
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -29,7 +30,7 @@ jobs:
                   
     - name: Deploy to GitHub pages
       uses: JamesIves/github-pages-deploy-action@4.1.4
-      if: ${{ github.ref == 'refs/heads/master' && startsWith(matrix.node-version, '12') }}
+      if: ${{ github.ref == 'refs/heads/master' && startsWith(matrix.node-version, '22') }}
       with:
         branch: gh-pages
         folder: .

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: grunt

--- a/src/parsing/cuvv.js
+++ b/src/parsing/cuvv.js
@@ -1,2 +1,35 @@
-BoxParser.createBoxCtor("cuvv", function(stream) {
+function VersionMap16(bitmap) {
+	this.bitmap = bitmap;
 }
+VersionMap16.prototype.toString = function () {
+    var i, versions = [];
+    for (i=0; i<16; i++)
+        if (this.bitmap &  (2, i))
+            versions.push(i+1);
+    return versions.length ===0 ? "none" : versions.join(" ");
+}
+function HighVersion(val) {
+	this.val = val;
+}
+VersHighVersionionMap16.prototype.toString = function () {
+    // table 5 in T/UWA 005-2.1
+    switch (this.val) {
+        case 0x0005: return "1.0";
+        case 0x0006: return "2.0";
+        case 0x0007: return "3.0";
+        case 0x0008: return "4.0";
+    }
+    return "unknown";
+}
+
+BoxParser.createBoxCtor("cuvv", function(stream) {
+    var i, reserved_zero;
+    this.cuva_version_map = new VersionMap16(stream.readUint16());
+
+    this.terminal_provide_code =  stream.readUint16();  // should be 0x0004
+
+    // according to T/UWA 005.2-1, this element contains the 'highest version in the current ES'
+    this.terminal_provide_oriented_code =  new HighVersion(stream.readUint16()); 
+    for (i=0; i<4; i++)
+        reserved_zero = stream.readUint32();
+});

--- a/src/parsing/cuvv.js
+++ b/src/parsing/cuvv.js
@@ -1,0 +1,2 @@
+BoxParser.createBoxCtor("cuvv", function(stream) {
+}


### PR DESCRIPTION
Add MP4 box support for signalling video bitstreams containing T/UWA 005 HDR DMI (HDR Vivid) metadata.

Signalling specification is [T/UWA 005-2.1](https://uhd-world-association.com/wp-content/uploads/2024/10/UWA-6-TUWA-005.2-1-2022-HDR-Video-Technology-Part-2-1-Application-Guide-to-System-Integration.pdf)