### PR TITLE
Add human friendly box names for ISOBMFF boxes.

### DIFF
--- a/src/parsing/CoLL.js
+++ b/src/parsing/CoLL.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("CoLL", function(stream) {
+BoxParser.createFullBoxCtor("CoLL", "ContentLightLevelBox", function(stream) {
 	this.maxCLL = stream.readUint16();
     this.maxFALL = stream.readUint16();
 });

--- a/src/parsing/SmDm.js
+++ b/src/parsing/SmDm.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("SmDm", function(stream) {
+BoxParser.createFullBoxCtor("SmDm", "SMPTE2086MasteringDisplayMetadataBox", function(stream) {
 	this.primaryRChromaticity_x = stream.readUint16();
     this.primaryRChromaticity_y = stream.readUint16();
     this.primaryGChromaticity_x = stream.readUint16();

--- a/src/parsing/a1lx.js
+++ b/src/parsing/a1lx.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("a1lx", function(stream) {
+BoxParser.createBoxCtor("a1lx", "AV1LayeredImageIndexingProperty", function(stream) {
 	var large_size = stream.readUint8() & 1;
 	var FieldLength = ((large_size & 1) + 1) * 16;
 	this.layer_size = [];

--- a/src/parsing/a1op.js
+++ b/src/parsing/a1op.js
@@ -1,3 +1,3 @@
-BoxParser.createBoxCtor("a1op", function(stream) {
+BoxParser.createBoxCtor("a1op", "OperatingPointSelectorProperty", function(stream) {
 	this.op_index = stream.readUint8();
 });

--- a/src/parsing/auxC.js
+++ b/src/parsing/auxC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("auxC", function(stream) {
+BoxParser.createFullBoxCtor("auxC", "AuxiliaryTypeProperty", function(stream) {
 	this.aux_type = stream.readCString();
 	var aux_subtype_length = this.size - this.hdr_size - (this.aux_type.length + 1);
 	this.aux_subtype = stream.readUint8Array(aux_subtype_length);

--- a/src/parsing/av1C.js
+++ b/src/parsing/av1C.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("av1C", function(stream) {
+BoxParser.createBoxCtor("av1C", "AV1CodecConfigurationBox", function(stream) {
 	var i;
 	var toparse;
 	var tmp = stream.readUint8();

--- a/src/parsing/avcC.js
+++ b/src/parsing/avcC.js
@@ -17,7 +17,7 @@ function printPS(ps) {
 	return str;
 }
 
-BoxParser.createBoxCtor("avcC", function(stream) {
+BoxParser.createBoxCtor("avcC", "AVCConfigurationBox", function(stream) {
 	var i;
 	var toparse;
 	this.configurationVersion = stream.readUint8();

--- a/src/parsing/btrt.js
+++ b/src/parsing/btrt.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("btrt", function(stream) {
+BoxParser.createBoxCtor("btrt", "BitRateBox", function(stream) {
 	this.bufferSizeDB = stream.readUint32();
 	this.maxBitrate = stream.readUint32();
 	this.avgBitrate = stream.readUint32();

--- a/src/parsing/ccst.js
+++ b/src/parsing/ccst.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("ccst", function(stream) {
+BoxParser.createFullBoxCtor("ccst", "CodingConstraintsBox", function(stream) {
 	var flags = stream.readUint8();
 	this.all_ref_pics_intra = ((flags & 0x80) == 0x80);
 	this.intra_pred_used = ((flags & 0x40) == 0x40);

--- a/src/parsing/cdef.js
+++ b/src/parsing/cdef.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("cdef", function(stream) {
+BoxParser.createBoxCtor("cdef", "ComponentDefinitionBox", function(stream) {
     var i;
     this.channel_count = stream.readUint16();
     this.channel_indexes = [];

--- a/src/parsing/clap.js
+++ b/src/parsing/clap.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("clap", function(stream) {
+BoxParser.createBoxCtor("clap", "CleanApertureBox", function(stream) {
 	this.cleanApertureWidthN = stream.readUint32();
 	this.cleanApertureWidthD = stream.readUint32();
 	this.cleanApertureHeightN = stream.readUint32();

--- a/src/parsing/clli.js
+++ b/src/parsing/clli.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("clli", function(stream) {
+BoxParser.createBoxCtor("clli", "ContentLightLevelBox", function(stream) {
 	this.max_content_light_level = stream.readUint16();
     this.max_pic_average_light_level = stream.readUint16();
 });

--- a/src/parsing/cmex.js
+++ b/src/parsing/cmex.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("cmex", function(stream) {
+BoxParser.createFullBoxCtor("cmex", "CameraExtrinsicMatrixProperty", function(stream) {
 	if (this.flags & 0x1) {
 		this.pos_x = stream.readInt32();
 	}

--- a/src/parsing/cmin.js
+++ b/src/parsing/cmin.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("cmin", function(stream) {
+BoxParser.createFullBoxCtor("cmin", "CameraIntrinsicMatrixProperty", function(stream) {
 	this.focal_length_x = stream.readInt32();
 	this.principal_point_x = stream.readInt32();
 	this.principal_point_y = stream.readInt32();

--- a/src/parsing/cmpd.js
+++ b/src/parsing/cmpd.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("cmpd", function(stream) {
+BoxParser.createBoxCtor("cmpd", "ComponentDefinitionBox", function(stream) {
 	this.component_count = stream.readUint32();
 	this.component_types = [];
 	this.component_type_urls = [];

--- a/src/parsing/co64.js
+++ b/src/parsing/co64.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("co64", function(stream) {
+BoxParser.createFullBoxCtor("co64", "ChunkLargeOffsetBox", function(stream) {
 	var entry_count;
 	var i;
 	entry_count = stream.readUint32();

--- a/src/parsing/colr.js
+++ b/src/parsing/colr.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("colr", function(stream) {
+BoxParser.createBoxCtor("colr", "ColourInformationBox", function(stream) {
 	this.colour_type = stream.readString(4);
 	if (this.colour_type === 'nclx') {
 		this.colour_primaries = stream.readUint16();

--- a/src/parsing/cprt.js
+++ b/src/parsing/cprt.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("cprt", function (stream) {
+BoxParser.createFullBoxCtor("cprt", "CopyrightBox", function (stream) {
 	this.parseLanguage(stream);
 	this.notice = stream.readCString();
 });

--- a/src/parsing/cslg.js
+++ b/src/parsing/cslg.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("cslg", function(stream) {
+BoxParser.createFullBoxCtor("cslg", "CompositionToDecodeBox", function(stream) {
 	var entry_count;
 	if (this.version === 0) {
 		this.compositionToDTSShift = stream.readInt32(); /* signed */

--- a/src/parsing/ctts.js
+++ b/src/parsing/ctts.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("ctts", function(stream) {
+BoxParser.createFullBoxCtor("ctts", "CompositionOffsetBox", function(stream) {
 	var entry_count;
 	var i;
 	entry_count = stream.readUint32();

--- a/src/parsing/dOps.js
+++ b/src/parsing/dOps.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("dOps", function(stream) {
+BoxParser.createBoxCtor("dOps", "OpusSpecificBox", function(stream) {
 	this.Version = stream.readUint8();
 	this.OutputChannelCount = stream.readUint8();
 	this.PreSkip = stream.readUint16();

--- a/src/parsing/dac3.js
+++ b/src/parsing/dac3.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("dac3", function(stream) {
+BoxParser.createBoxCtor("dac3", "AC3SpecificBox", function(stream) {
 	var tmp_byte1 = stream.readUint8();
 	var tmp_byte2 = stream.readUint8();
 	var tmp_byte3 = stream.readUint8();

--- a/src/parsing/dec3.js
+++ b/src/parsing/dec3.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("dec3", function(stream) {
+BoxParser.createBoxCtor("dec3", "EC3SpecificBox", function(stream) {
 	var tmp_16 = stream.readUint16();
 	this.data_rate = tmp_16 >> 3;
 	this.num_ind_sub = tmp_16 & 0x7;

--- a/src/parsing/dfLa.js
+++ b/src/parsing/dfLa.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("dfLa", function(stream) {
+BoxParser.createFullBoxCtor("dfLa", "FLACSpecificBox", function(stream) {
     var BLOCKTYPE_MASK = 0x7F;
     var LASTMETADATABLOCKFLAG_MASK = 0x80;
 

--- a/src/parsing/dimm.js
+++ b/src/parsing/dimm.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("dimm", function(stream) {
+BoxParser.createBoxCtor("dimm", "hintimmediateBytesSent", function(stream) {
 	this.bytessent = stream.readUint64();
 });
 

--- a/src/parsing/dmax.js
+++ b/src/parsing/dmax.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("dmax", function(stream) {
+BoxParser.createBoxCtor("dmax", "hintlongestpacket", function(stream) {
 	this.time = stream.readUint32();
 });
 

--- a/src/parsing/dmed.js
+++ b/src/parsing/dmed.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("dmed", function(stream) {
+BoxParser.createBoxCtor("dmed", "hintmediaBytesSent", function(stream) {
 	this.bytessent = stream.readUint64();
 });
 

--- a/src/parsing/dref.js
+++ b/src/parsing/dref.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("dref", function(stream) {
+BoxParser.createFullBoxCtor("dref", "DataReferenceBox", function(stream) {
 	var ret;
 	var box;
 	this.entries = [];

--- a/src/parsing/drep.js
+++ b/src/parsing/drep.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("drep", function(stream) {
+BoxParser.createBoxCtor("drep", "hintrepeatedBytesSent", function(stream) {
 	this.bytessent = stream.readUint64();
 });
 

--- a/src/parsing/elng.js
+++ b/src/parsing/elng.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("elng", function(stream) {
+BoxParser.createFullBoxCtor("elng", "ExtendedLanguageBox", function(stream) {
 	this.extended_language = stream.readString(this.size-this.hdr_size);
 });
 

--- a/src/parsing/elst.js
+++ b/src/parsing/elst.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("elst", function(stream) {
+BoxParser.createFullBoxCtor("elst", "EditListBox", function(stream) {
 	this.entries = [];
 	var entry_count = stream.readUint32();
 	for (var i = 0; i < entry_count; i++) {

--- a/src/parsing/emsg.js
+++ b/src/parsing/emsg.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("emsg", function(stream) {
+BoxParser.createFullBoxCtor("emsg", "EventMessageBox", function(stream) {
 	if (this.version == 1) {
 		this.timescale 					= stream.readUint32();
 		this.presentation_time 			= stream.readUint64();

--- a/src/parsing/esds.js
+++ b/src/parsing/esds.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("esds", function(stream) {
+BoxParser.createFullBoxCtor("esds", "ElementaryStreamDescriptorBox", function(stream) {
 	var esd_data = stream.readUint8Array(this.size-this.hdr_size);
 	if (typeof MPEG4DescriptorParser !== "undefined") {
 		var esd_parser = new MPEG4DescriptorParser();

--- a/src/parsing/fiel.js
+++ b/src/parsing/fiel.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("fiel", function(stream) {
+BoxParser.createBoxCtor("fiel", "FieldHandlingBox", function(stream) {
 	this.fieldCount = stream.readUint8();
 	this.fieldOrdering = stream.readUint8();
 });

--- a/src/parsing/frma.js
+++ b/src/parsing/frma.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("frma", function(stream) {
+BoxParser.createBoxCtor("frma", "OriginalFormatBox", function(stream) {
 	this.data_format = stream.readString(4);
 });
 

--- a/src/parsing/ftyp.js
+++ b/src/parsing/ftyp.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("ftyp", function(stream) {
+BoxParser.createBoxCtor("ftyp", "FileTypeBox", function(stream) {
 	var toparse = this.size - this.hdr_size;
 	this.major_brand = stream.readString(4);
 	this.minor_version = stream.readUint32();

--- a/src/parsing/hdlr.js
+++ b/src/parsing/hdlr.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("hdlr", function(stream) {
+BoxParser.createFullBoxCtor("hdlr", "HandlerBox", function(stream) {
 	if (this.version === 0) {
 		stream.readUint32();
 		this.handler = stream.readString(4);

--- a/src/parsing/hvcC.js
+++ b/src/parsing/hvcC.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("hvcC", function(stream) {
+BoxParser.createBoxCtor("hvcC", "HEVCConfigurationBox", function(stream) {
 	var i, j;
 	var nb_nalus;
 	var length;

--- a/src/parsing/iinf.js
+++ b/src/parsing/iinf.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("iinf", function(stream) {
+BoxParser.createFullBoxCtor("iinf", "ItemInfoBox", function(stream) {
 	var ret;
 	if (this.version === 0) {
 		this.entry_count = stream.readUint16();

--- a/src/parsing/iloc.js
+++ b/src/parsing/iloc.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("iloc", function(stream) {
+BoxParser.createFullBoxCtor("iloc", "ItemLocationBox", function(stream) {
 	var byte;
 	byte = stream.readUint8();
 	this.offset_size = (byte >> 4) & 0xF;

--- a/src/parsing/imir.js
+++ b/src/parsing/imir.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("imir", function(stream) {
+BoxParser.createBoxCtor("imir", "ImageMirror", function(stream) {
 	var tmp = stream.readUint8();
 	this.reserved = tmp >> 7;
 	this.axis = tmp & 1;

--- a/src/parsing/infe.js
+++ b/src/parsing/infe.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("infe", function(stream) {
+BoxParser.createFullBoxCtor("infe", "ItemInfoEntry", function(stream) {
 	if (this.version === 0 || this.version === 1) {
 		this.item_ID = stream.readUint16();
 		this.item_protection_index = stream.readUint16();

--- a/src/parsing/ipma.js
+++ b/src/parsing/ipma.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("ipma", function(stream) {
+BoxParser.createFullBoxCtor("ipma", "ItemPropertyAssociationBox", function(stream) {
 	var i, j;
 	entry_count = stream.readUint32();
 	this.associations = [];

--- a/src/parsing/iref.js
+++ b/src/parsing/iref.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("iref", function(stream) {
+BoxParser.createFullBoxCtor("iref", "ItemReferenceBox", function(stream) {
 	var ret;
 	var entryCount;
 	var box;

--- a/src/parsing/irot.js
+++ b/src/parsing/irot.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("irot", function(stream) {
+BoxParser.createBoxCtor("irot", "ImageRotation", function(stream) {
 	this.angle = stream.readUint8() & 0x3;
 });
 

--- a/src/parsing/ispe.js
+++ b/src/parsing/ispe.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("ispe", function(stream) {
+BoxParser.createFullBoxCtor("ispe", "ImageSpatialExtentsProperty", function(stream) {
 	this.image_width = stream.readUint32();
 	this.image_height = stream.readUint32();
 });

--- a/src/parsing/kind.js
+++ b/src/parsing/kind.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("kind", function(stream) {
+BoxParser.createFullBoxCtor("kind", "KindBox", function(stream) {
 	this.schemeURI = stream.readCString();
 	this.value = stream.readCString();
 });

--- a/src/parsing/leva.js
+++ b/src/parsing/leva.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("leva", function(stream) {
+BoxParser.createFullBoxCtor("leva", "LevelAssignmentBox", function(stream) {
 	var count = stream.readUint8();
 	this.levels = [];
 	for (var i = 0; i < count; i++) {

--- a/src/parsing/lhvC.js
+++ b/src/parsing/lhvC.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("lhvC", function(stream) {
+BoxParser.createBoxCtor("lhvC", "LHEVCConfigurationBox", function(stream) {
 	var i, j;
 	var tmp_byte;
 	this.configurationVersion = stream.readUint8();

--- a/src/parsing/lsel.js
+++ b/src/parsing/lsel.js
@@ -1,3 +1,3 @@
-BoxParser.createBoxCtor("lsel", function(stream) {
+BoxParser.createBoxCtor("lsel", "LayerSelectorProperty", function(stream) {
 	this.layer_id = stream.readUint16();
 });

--- a/src/parsing/maxr.js
+++ b/src/parsing/maxr.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("maxr", function(stream) {
+BoxParser.createBoxCtor("maxr", "hintmaxrate", function(stream) {
 	this.period = stream.readUint32();
 	this.bytes = stream.readUint32();
 });

--- a/src/parsing/mdcv.js
+++ b/src/parsing/mdcv.js
@@ -7,7 +7,7 @@ ColorPoint.prototype.toString = function() {
     return "("+this.x+","+this.y+")";
 }
 
-BoxParser.createBoxCtor("mdcv", function(stream) {
+BoxParser.createBoxCtor("mdcv", "MasteringDisplayColourVolumeBox", function(stream) {
     this.display_primaries = [];
     this.display_primaries[0] = new ColorPoint(stream.readUint16(),stream.readUint16());
     this.display_primaries[1] = new ColorPoint(stream.readUint16(),stream.readUint16());

--- a/src/parsing/mdhd.js
+++ b/src/parsing/mdhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("mdhd", function(stream) {
+BoxParser.createFullBoxCtor("mdhd", "MediaHeaderBox", function(stream) {
 	if (this.version == 1) {
 		this.creation_time = stream.readUint64();
 		this.modification_time = stream.readUint64();

--- a/src/parsing/mehd.js
+++ b/src/parsing/mehd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("mehd", function(stream) {
+BoxParser.createFullBoxCtor("mehd", "MovieExtendsHeaderBox", function(stream) {
 	if (this.flags & 0x1) {
 		Log.warn("BoxParser", "mehd box incorrectly uses flags set to 1, converting version to 1");
 		this.version = 1;

--- a/src/parsing/meta.js
+++ b/src/parsing/meta.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("meta", function(stream) {
+BoxParser.createFullBoxCtor("meta", "MetaBox", function(stream) {
 	this.boxes = [];
 	BoxParser.ContainerBox.prototype.parse.call(this, stream);
 });

--- a/src/parsing/mfhd.js
+++ b/src/parsing/mfhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("mfhd", function(stream) {
+BoxParser.createFullBoxCtor("mfhd", "MovieFragmentHeaderBox", function(stream) {
 	this.sequence_number = stream.readUint32();
 });
 

--- a/src/parsing/mfro.js
+++ b/src/parsing/mfro.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("mfro", function(stream) {
+BoxParser.createFullBoxCtor("mfro", "MovieFragmentRandomAccessOffsetBox", function(stream) {
 	this._size = stream.readUint32();
 });
 

--- a/src/parsing/mskC.js
+++ b/src/parsing/mskC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("mskC", function(stream) {
+BoxParser.createFullBoxCtor("mskC", "MaskConfigurationProperty", function(stream) {
     this.bits_per_pixel = stream.readUint8();
 });
 

--- a/src/parsing/mvhd.js
+++ b/src/parsing/mvhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("mvhd", function(stream) {
+BoxParser.createFullBoxCtor("mvhd", "MovieHeaderBox", function(stream) {
 	if (this.version == 1) {
 		this.creation_time = stream.readUint64();
 		this.modification_time = stream.readUint64();

--- a/src/parsing/npck.js
+++ b/src/parsing/npck.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("npck", function(stream) {
+BoxParser.createBoxCtor("npck", "hintPacketsSent", function(stream) {
 	this.packetssent = stream.readUint32();
 });
 

--- a/src/parsing/nump.js
+++ b/src/parsing/nump.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("nump", function(stream) {
+BoxParser.createBoxCtor("nump", "hintPacketsSent", function(stream) {
 	this.packetssent = stream.readUint64();
 });
 

--- a/src/parsing/padb.js
+++ b/src/parsing/padb.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("padb", function(stream) {
+BoxParser.createFullBoxCtor("padb", "PaddingBitsBox", function(stream) {
 	var sample_count = stream.readUint32();
 	this.padbits = [];
 	for (var i = 0; i < Math.floor((sample_count+1)/2); i++) {

--- a/src/parsing/pasp.js
+++ b/src/parsing/pasp.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("pasp", function(stream) {
+BoxParser.createBoxCtor("pasp", "PixelAspectRatioBox", function(stream) {
 	this.hSpacing = stream.readUint32();
 	this.vSpacing = stream.readUint32();
 });

--- a/src/parsing/payl.js
+++ b/src/parsing/payl.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("payl", function(stream) {
+BoxParser.createBoxCtor("payl", "CuePayloadBox", function(stream) {
 	this.text = stream.readString(this.size - this.hdr_size);
 });
 

--- a/src/parsing/payt.js
+++ b/src/parsing/payt.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("payt", function(stream) {
+BoxParser.createBoxCtor("payt", "hintpayloadID", function(stream) {
 	this.payloadID = stream.readUint32();
 	var count = stream.readUint8();
 	this.rtpmap_string = stream.readString(count);

--- a/src/parsing/pdin.js
+++ b/src/parsing/pdin.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("pdin", function(stream) {
+BoxParser.createFullBoxCtor("pdin", "ProgressiveDownloadInfoBox", function(stream) {
 	var count = (this.size - this.hdr_size)/8;
 	this.rate = [];
 	this.initial_delay = [];

--- a/src/parsing/pitm.js
+++ b/src/parsing/pitm.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("pitm", function(stream) {
+BoxParser.createFullBoxCtor("pitm", "PrimaryItemBox", function(stream) {
 	if (this.version === 0) {
 		this.item_id = stream.readUint16();
 	} else {

--- a/src/parsing/pixi.js
+++ b/src/parsing/pixi.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("pixi", function(stream) {
+BoxParser.createFullBoxCtor("pixi", "PixelInformationProperty", function(stream) {
 	var i;
 	this.num_channels = stream.readUint8();
 	this.bits_per_channels = [];

--- a/src/parsing/pmax.js
+++ b/src/parsing/pmax.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("pmax", function(stream) {
+BoxParser.createBoxCtor("pmax", "hintlargestpacket", function(stream) {
 	this.bytes = stream.readUint32();
 });
 

--- a/src/parsing/prdi.js
+++ b/src/parsing/prdi.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("prdi", function(stream) {
+BoxParser.createFullBoxCtor("prdi", "ProgressiveDerivedImageItemInformationProperty", function(stream) {
 	this.step_count = stream.readUint16();
 	this.item_count = [];
 	if (this.flags & 0x2) {

--- a/src/parsing/prft.js
+++ b/src/parsing/prft.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("prft", function(stream) {
+BoxParser.createFullBoxCtor("prft", "ProducerReferenceTimeBox", function(stream) {
 	this.ref_track_id = stream.readUint32();
 	this.ntp_timestamp = stream.readUint64();
 	if (this.version === 0) {

--- a/src/parsing/pssh.js
+++ b/src/parsing/pssh.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("pssh", function(stream) {
+BoxParser.createFullBoxCtor("pssh", "ProtectionSystemSpecificHeaderBox", function(stream) {
 	this.system_id = BoxParser.parseHex16(stream);
 	if (this.version > 0) {
 		var count = stream.readUint32();

--- a/src/parsing/qt/clef.js
+++ b/src/parsing/qt/clef.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("clef", function(stream) {
+BoxParser.createFullBoxCtor("clef", "TrackCleanApertureDimensionsBox", function(stream) {
 	this.width = stream.readUint32();
 	this.height = stream.readUint32();
 });

--- a/src/parsing/qt/enof.js
+++ b/src/parsing/qt/enof.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("enof", function(stream) {
+BoxParser.createFullBoxCtor("enof", "TrackEncodedPixelsDimensionsBox", function(stream) {
 	this.width = stream.readUint32();
 	this.height = stream.readUint32();
 });

--- a/src/parsing/qt/prof.js
+++ b/src/parsing/qt/prof.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("prof", function(stream) {
+BoxParser.createFullBoxCtor("prof", "TrackProductionApertureDimensionsBox", function(stream) {
 	this.width = stream.readUint32();
 	this.height = stream.readUint32();
 });

--- a/src/parsing/qt/tapt.js
+++ b/src/parsing/qt/tapt.js
@@ -1,1 +1,1 @@
-BoxParser.createContainerBoxCtor("tapt", null, [ "clef", "prof", "enof"]);
+BoxParser.createContainerBoxCtor("tapt", "TrackApertureModeDimensionsBox", null, [ "clef", "prof", "enof"]);

--- a/src/parsing/rtp.js
+++ b/src/parsing/rtp.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("rtp ", function(stream) {
+BoxParser.createBoxCtor("rtp ", "rtpmoviehintinformation", function(stream) {
 	this.descriptionformat = stream.readString(4);
 	this.sdptext = stream.readString(this.size - this.hdr_size - 4);
 });

--- a/src/parsing/saio.js
+++ b/src/parsing/saio.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("saio", function(stream) {
+BoxParser.createFullBoxCtor("saio", "SampleAuxiliaryInformationOffsetsBox", function(stream) {
 	if (this.flags & 0x1) {
 		this.aux_info_type = stream.readString(4);
 		this.aux_info_type_parameter = stream.readUint32();

--- a/src/parsing/saiz.js
+++ b/src/parsing/saiz.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("saiz", function(stream) {
+BoxParser.createFullBoxCtor("saiz", "SampleAuxiliaryInformationSizesBox", function(stream) {
 	if (this.flags & 0x1) {
 		this.aux_info_type = stream.readString(4);
 		this.aux_info_type_parameter = stream.readUint32();

--- a/src/parsing/sbgp.js
+++ b/src/parsing/sbgp.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("sbgp", function(stream) {
+BoxParser.createFullBoxCtor("sbgp", "SampleToGroupBox", function(stream) {
 	this.grouping_type = stream.readString(4);
 	if (this.version === 1) {
 		this.grouping_type_parameter = stream.readUint32();

--- a/src/parsing/sbpm.js
+++ b/src/parsing/sbpm.js
@@ -7,7 +7,7 @@ Pixel.prototype.toString = function pixelToString() {
 	return "[row: " + this.bad_pixel_row + ", column: " + this.bad_pixel_column + "]";
 }
 
-BoxParser.createFullBoxCtor("sbpm", function(stream) {
+BoxParser.createFullBoxCtor("sbpm", "SensorBadPixelsMapBox", function(stream) {
 	var i;
 	this.component_count = stream.readUint16();
     this.component_index = [];

--- a/src/parsing/schm.js
+++ b/src/parsing/schm.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("schm", function(stream) {
+BoxParser.createFullBoxCtor("schm", "SchemeTypeBox", function(stream) {
 	this.scheme_type = stream.readString(4);
 	this.scheme_version = stream.readUint32();
 	if (this.flags & 0x000001) {

--- a/src/parsing/sdp.js
+++ b/src/parsing/sdp.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("sdp ", function(stream) {
+BoxParser.createBoxCtor("sdp ", "rtptracksdphintinformation", function(stream) {
 	this.sdptext = stream.readString(this.size - this.hdr_size);
 });
 

--- a/src/parsing/sdtp.js
+++ b/src/parsing/sdtp.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("sdtp", function(stream) {
+BoxParser.createFullBoxCtor("sdtp", "SampleDependencyTypeBox", function(stream) {
 	var tmp_byte;
 	var count = (this.size - this.hdr_size);
 	this.is_leading = [];

--- a/src/parsing/senc.js
+++ b/src/parsing/senc.js
@@ -1,5 +1,5 @@
 // Cannot be fully parsed because Per_Sample_IV_Size needs to be known
-BoxParser.createFullBoxCtor("senc" /*, function(stream) {
+BoxParser.createFullBoxCtor("senc", "SampleEncryptionBox" /*, function(stream) {
 	this.parseFullHeader(stream);
 	var sample_count = stream.readUint32();
 	this.samples = [];

--- a/src/parsing/sgpd.js
+++ b/src/parsing/sgpd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("sgpd", function(stream) {
+BoxParser.createFullBoxCtor("sgpd", "SampleGroupDescriptionBox", function(stream) {
 	this.grouping_type = stream.readString(4);
 	Log.debug("BoxParser", "Found Sample Groups of type "+this.grouping_type);
 	if (this.version === 1) {

--- a/src/parsing/sidx.js
+++ b/src/parsing/sidx.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("sidx", function(stream) {
+BoxParser.createFullBoxCtor("sidx", "CompressedSegmentIndexBox", function(stream) {
 	this.reference_ID = stream.readUint32();
 	this.timescale = stream.readUint32();
 	if (this.version === 0) {

--- a/src/parsing/smhd.js
+++ b/src/parsing/smhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("smhd", function(stream) {
+BoxParser.createFullBoxCtor("smhd", "SoundMediaHeaderBox", function(stream) {
 	this.balance = stream.readUint16();
 	stream.readUint16();
 });

--- a/src/parsing/ssix.js
+++ b/src/parsing/ssix.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("ssix", function(stream) {
+BoxParser.createFullBoxCtor("ssix", "CompressedSubsegmentIndexBox", function(stream) {
 	this.subsegments = [];
 	var subsegment_count = stream.readUint32();
 	for (var i = 0; i < subsegment_count; i++) {

--- a/src/parsing/stco.js
+++ b/src/parsing/stco.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stco", function(stream) {
+BoxParser.createFullBoxCtor("stco", "ChunkOffsetBox", function(stream) {
 	var entry_count;
 	entry_count = stream.readUint32();
 	this.chunk_offsets = [];

--- a/src/parsing/stdp.js
+++ b/src/parsing/stdp.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stdp", function(stream) {
+BoxParser.createFullBoxCtor("stdp", "DegradationPriorityBox", function(stream) {
 	var count = (this.size - this.hdr_size)/2;
 	this.priority = [];
 	for (var i = 0; i < count; i++) {

--- a/src/parsing/sthd.js
+++ b/src/parsing/sthd.js
@@ -1,2 +1,2 @@
-BoxParser.createFullBoxCtor("sthd");
+BoxParser.createFullBoxCtor("sthd", "SubtitleMediaHeaderBox");
 

--- a/src/parsing/stri.js
+++ b/src/parsing/stri.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stri", function(stream) {
+BoxParser.createFullBoxCtor("stri", "SubTrackInformationBox", function(stream) {
 	this.switch_group = stream.readUint16();
 	this.alternate_group = stream.readUint16();
 	this.sub_track_id = stream.readUint32();

--- a/src/parsing/stsc.js
+++ b/src/parsing/stsc.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stsc", function(stream) {
+BoxParser.createFullBoxCtor("stsc", "SampleToChunkBox", function(stream) {
 	var entry_count;
 	var i;
 	entry_count = stream.readUint32();

--- a/src/parsing/stsd.js
+++ b/src/parsing/stsd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stsd", function(stream) {
+BoxParser.createFullBoxCtor("stsd", "SampleDescriptionBox", function(stream) {
 	var i;
 	var ret;
 	var entryCount;

--- a/src/parsing/stsg.js
+++ b/src/parsing/stsg.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stsg", function(stream) {
+BoxParser.createFullBoxCtor("stsg", "SubTrackSampleGroupBox", function(stream) {
 	this.grouping_type = stream.readUint32();
 	var count = stream.readUint16();
 	this.group_description_index = [];

--- a/src/parsing/stsh.js
+++ b/src/parsing/stsh.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stsh", function(stream) {
+BoxParser.createFullBoxCtor("stsh", "ShadowSyncSampleBox", function(stream) {
 	var entry_count;
 	var i;
 	entry_count = stream.readUint32();

--- a/src/parsing/stss.js
+++ b/src/parsing/stss.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stss", function(stream) {
+BoxParser.createFullBoxCtor("stss", "SyncSampleBox", function(stream) {
 	var i;
 	var entry_count;
 	entry_count = stream.readUint32();

--- a/src/parsing/stsz.js
+++ b/src/parsing/stsz.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stsz", function(stream) {
+BoxParser.createFullBoxCtor("stsz", "SampleSizeBox", function(stream) {
 	var i;
 	this.sample_sizes = [];
 	if (this.version === 0) {

--- a/src/parsing/stts.js
+++ b/src/parsing/stts.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stts", function(stream) {
+BoxParser.createFullBoxCtor("stts", "TimeToSampleBox", function(stream) {
 	var entry_count;
 	var i;
 	var delta;

--- a/src/parsing/stvi.js
+++ b/src/parsing/stvi.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stvi", function(stream) {
+BoxParser.createFullBoxCtor("stvi", "StereoVideoBox", function(stream) {
 	var tmp32 = stream.readUint32();
 	this.single_view_allowed = tmp32 & 0x3;
 	this.stereo_scheme = stream.readUint32();

--- a/src/parsing/styp.js
+++ b/src/parsing/styp.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("styp", function(stream) {
+BoxParser.createBoxCtor("styp", "SegmentTypeBox", function(stream) {
 	BoxParser.ftypBox.prototype.parse.call(this, stream);
 });
 

--- a/src/parsing/stz2.js
+++ b/src/parsing/stz2.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("stz2", function(stream) {
+BoxParser.createFullBoxCtor("stz2", "CompactSampleSizeBox", function(stream) {
 	var i;
 	var sample_size;
 	var sample_count;

--- a/src/parsing/subs.js
+++ b/src/parsing/subs.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("subs", function(stream) {
+BoxParser.createFullBoxCtor("subs", "SubSampleInformationBox", function(stream) {
 	var i,j;
 	var entry_count;
 	var subsample_count;

--- a/src/parsing/tenc.js
+++ b/src/parsing/tenc.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("tenc", function(stream) {
+BoxParser.createFullBoxCtor("tenc", "TrackEncryptionBox", function(stream) {
 	stream.readUint8(); // reserved
 	if (this.version === 0) {
 		stream.readUint8();

--- a/src/parsing/tfdt.js
+++ b/src/parsing/tfdt.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("tfdt", function(stream) {
+BoxParser.createFullBoxCtor("tfdt", "TrackFragmentBaseMediaDecodeTimeBox", function(stream) {
 	if (this.version == 1) {
 		this.baseMediaDecodeTime = stream.readUint64();
 	} else {

--- a/src/parsing/tfhd.js
+++ b/src/parsing/tfhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("tfhd", function(stream) {
+BoxParser.createFullBoxCtor("tfhd", "TrackFragmentHeaderBox", function(stream) {
 	var readBytes = 0;
 	this.track_id = stream.readUint32();
 	if (this.size - this.hdr_size > readBytes && (this.flags & BoxParser.TFHD_FLAG_BASE_DATA_OFFSET)) {

--- a/src/parsing/tfra.js
+++ b/src/parsing/tfra.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("tfra", function(stream) {
+BoxParser.createFullBoxCtor("tfra", "TrackFragmentRandomAccessBox", function(stream) {
 	this.track_ID = stream.readUint32();
 	stream.readUint24();
 	var tmp_byte = stream.readUint8();

--- a/src/parsing/tkhd.js
+++ b/src/parsing/tkhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("tkhd", function(stream) {
+BoxParser.createFullBoxCtor("tkhd", "TrackHeaderBox", function(stream) {
 	if (this.version == 1) {
 		this.creation_time = stream.readUint64();
 		this.modification_time = stream.readUint64();

--- a/src/parsing/tmax.js
+++ b/src/parsing/tmax.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("tmax", function(stream) {
+BoxParser.createBoxCtor("tmax", "hintmaxrelativetime", function(stream) {
 	this.time = stream.readUint32();
 });
 

--- a/src/parsing/tmin.js
+++ b/src/parsing/tmin.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("tmin", function(stream) {
+BoxParser.createBoxCtor("tmin", "hintminrelativetime", function(stream) {
 	this.time = stream.readUint32();
 });
 

--- a/src/parsing/totl.js
+++ b/src/parsing/totl.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("totl",function(stream) {
+BoxParser.createBoxCtor("totl", "hintBytesSent", function(stream) {
 	this.bytessent = stream.readUint32();
 });
 

--- a/src/parsing/tpay.js
+++ b/src/parsing/tpay.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("tpay", function(stream) {
+BoxParser.createBoxCtor("tpay", "hintBytesSent", function(stream) {
 	this.bytessent = stream.readUint32();
 });
 

--- a/src/parsing/tpyl.js
+++ b/src/parsing/tpyl.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("tpyl", function(stream) {
+BoxParser.createBoxCtor("tpyl", "hintBytesSent", function(stream) {
 	this.bytessent = stream.readUint64();
 });
 

--- a/src/parsing/trep.js
+++ b/src/parsing/trep.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("trep", function(stream) {
+BoxParser.createFullBoxCtor("trep", "TrackExtensionPropertiesBox", function(stream) {
 	this.track_ID = stream.readUint32();
 	this.boxes = [];
 	while (stream.getPosition() < this.start+this.size) {

--- a/src/parsing/trex.js
+++ b/src/parsing/trex.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("trex", function(stream) {
+BoxParser.createFullBoxCtor("trex", "TrackExtendsBox", function(stream) {
 	this.track_id = stream.readUint32();
 	this.default_sample_description_index = stream.readUint32();
 	this.default_sample_duration = stream.readUint32();

--- a/src/parsing/trpy.js
+++ b/src/parsing/trpy.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("trpy", function(stream) {
+BoxParser.createBoxCtor("trpy", "hintBytesSent", function(stream) {
 	this.bytessent = stream.readUint64();
 });
 

--- a/src/parsing/trun.js
+++ b/src/parsing/trun.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("trun", function(stream) {
+BoxParser.createFullBoxCtor("trun", "TrackRunBox", function(stream) {
 	var readBytes = 0;
 	this.sample_count = stream.readUint32();
 	readBytes+= 4;

--- a/src/parsing/tsel.js
+++ b/src/parsing/tsel.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("tsel", function(stream) {
+BoxParser.createFullBoxCtor("tsel", "TrackSelectionBox", function(stream) {
 	this.switch_group = stream.readUint32();
 	var count = (this.size - this.hdr_size - 4)/4;
 	this.attribute_list = [];

--- a/src/parsing/txtC.js
+++ b/src/parsing/txtC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("txtC", function(stream) {
+BoxParser.createFullBoxCtor("txtC", "TextConfigBox", function(stream) {
 	this.config = stream.readCString();
 });
 

--- a/src/parsing/tyco.js
+++ b/src/parsing/tyco.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("tyco", function(stream) {
+BoxParser.createBoxCtor("tyco", "TypeCombinationBox", function(stream) {
 	var count = (this.size - this.hdr_size) / 4;
 	this.compatible_brands = [];
 	for (var i = 0; i < count; i++) {

--- a/src/parsing/udes.js
+++ b/src/parsing/udes.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("udes", function(stream) {
+BoxParser.createFullBoxCtor("udes", "UserDescriptionProperty", function(stream) {
 	this.lang = stream.readCString();
 	this.name = stream.readCString();
 	this.description = stream.readCString();

--- a/src/parsing/uncC.js
+++ b/src/parsing/uncC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("uncC", function(stream) {
+BoxParser.createFullBoxCtor("uncC", "UncompressedFrameConfigBox", function(stream) {
     var i;
     this.profile = stream.readString(4);
     if (this.version == 1) {

--- a/src/parsing/url.js
+++ b/src/parsing/url.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("url ", function(stream) {
+BoxParser.createFullBoxCtor("url ", "DataEntryUrlBox", function(stream) {
 	if (this.flags !== 0x000001) {
 		this.location = stream.readCString();
 	}

--- a/src/parsing/urn.js
+++ b/src/parsing/urn.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("urn ", function(stream) {
+BoxParser.createFullBoxCtor("urn ", "DataEntryUrnBox", function(stream) {
 	this.name = stream.readCString();
 	if (this.size - this.hdr_size - this.name.length - 1 > 0) {
 		this.location = stream.readCString();

--- a/src/parsing/vmhd.js
+++ b/src/parsing/vmhd.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("vmhd", function(stream) {
+BoxParser.createFullBoxCtor("vmhd", "VideoMediaHeaderBox", function(stream) {
 	this.graphicsmode = stream.readUint16();
 	this.opcolor = stream.readUint16Array(3);
 });

--- a/src/parsing/vpcC.js
+++ b/src/parsing/vpcC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("vpcC", function (stream) {
+BoxParser.createFullBoxCtor("vpcC", "VPCodecConfigurationRecord", function (stream) {
 	var tmp;
 	if (this.version === 1) {
 		this.profile = stream.readUint8();

--- a/src/parsing/vttC.js
+++ b/src/parsing/vttC.js
@@ -1,4 +1,4 @@
-BoxParser.createBoxCtor("vttC", function(stream) {
+BoxParser.createBoxCtor("vttC", "WebVTTConfigurationBox", function(stream) {
 	this.text = stream.readString(this.size - this.hdr_size);
 });
 

--- a/src/parsing/vvcC.js
+++ b/src/parsing/vvcC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("vvcC", function (stream) {
+BoxParser.createFullBoxCtor("vvcC", "VvcConfigurationBox", function (stream) {
   var i, j;
 
   // helper object to simplify extracting individual bits

--- a/src/parsing/vvnC.js
+++ b/src/parsing/vvnC.js
@@ -1,4 +1,4 @@
-BoxParser.createFullBoxCtor("vvnC", function (stream) {
+BoxParser.createFullBoxCtor("vvnC", "VvcNALUConfigBox", function (stream) {
   // VvcNALUConfigBox
   var tmp = strm.readUint8();
   this.lengthSizeMinusOne = (tmp & 0x3);

--- a/test/boxfancytree.js
+++ b/test/boxfancytree.js
@@ -26,6 +26,9 @@ function getFancyTreeDataFromBoxes(boxes) {
 		var fancytree_node = {};
 		array.push(fancytree_node);
 		fancytree_node.title = box.type || i;
+		if (box.box_name) {
+			fancytree_node.title += ' <span class="boxname">(' + box.box_name + ')</span>';
+		}
 		fancytree_node.data = { 'box': box };
 		var child_prop_names = [ "boxes", "entries", "references", "subsamples",
 								 "items", "item_infos", "extents", "associations", "subsegments", "ranges", "seekLists", "seekPoints", "esd", "levels", "props"];

--- a/test/style.css
+++ b/test/style.css
@@ -109,3 +109,7 @@ th {
 .trackinfo table tr td, trackinfo table tr th, #sampletable table tr td, #sampletable table tr th {
 	width: 1px;
 }
+
+.boxname {
+	color: #777;
+}


### PR DESCRIPTION
Show the names in the test/filereader.html UI.

Most box names come from https://mpeggroup.github.io/FileFormatConformance/ e.g. https://mpeggroup.github.io/FileFormatConformance/?query=%3D%22moov%22 and/or https://mp4ra.org/search when available there.

More box names can be added, in particular in EntityToGroup.js but I think this is a good start.
  
filereader.html looks like this:
<img width="904" alt="Screenshot 2025-03-14 at 13 29 21" src="https://github.com/user-attachments/assets/cf5d1710-77a5-4400-a2f4-3c479d3c35ba" />
