### PR TITLE
Fix mvex child box name to be trex

### DIFF
--- a/src/box.js
+++ b/src/box.js
@@ -33,7 +33,7 @@ var BoxParser = {
 		[{type: "minf", name: "MediaInformationBox"}],
 		[{type: "dinf", name: "DataInformationBox"}],
 		[{type: "stbl", name: "SampleTableBox"}, ["sgpd", "sbgp"]],
-		[{type: "mvex", name: "MovieExtendsBox"}, ["tref"]],
+		[{type: "mvex", name: "MovieExtendsBox"}, ["trex"]],
 		[{type: "moof", name: "CompressedMovieFragmentBox"}, ["traf"]],
 		[{type: "traf", name: "TrackFragmentBox"}, ["trun", "sgpd", "sbgp"]],
 		[{type: "vttc", name: "VTTCueBox"}],


### PR DESCRIPTION
This was accidentally broken in #438 and it prevents loading fragmented mp4 since the trexs property does not exist anymore in `ISOFile.getTrexById`

![image](https://github.com/user-attachments/assets/37a86bf7-2ef5-41cc-b72e-0bcb6a8f49b7)
