### PR TITLE
Fix forbidden bit check in av1C parsing

### DIFF
--- a/src/parsing/av1C.js
+++ b/src/parsing/av1C.js
@@ -2,7 +2,7 @@ BoxParser.createBoxCtor("av1C", "AV1CodecConfigurationBox", function(stream) {
 	var i;
 	var toparse;
 	var tmp = stream.readUint8();
-	if ((tmp >> 7 & 0x1) !== 0) {
+	if ((tmp >> 7 & 0x1) !== 1) {
 		Log.error("av1C marker problem");
 		return;
 	}

--- a/src/parsing/av1C.js
+++ b/src/parsing/av1C.js
@@ -2,7 +2,7 @@ BoxParser.createBoxCtor("av1C", "AV1CodecConfigurationBox", function(stream) {
 	var i;
 	var toparse;
 	var tmp = stream.readUint8();
-	if ((tmp >> 7) & 0x1 !== 1) {
+	if ((tmp >> 7 & 0x1) !== 0) {
 		Log.error("av1C marker problem");
 		return;
 	}


### PR DESCRIPTION
I'm not a 100% familiar with AV1 but I think this is how it is supposed to be fixed.

`(tmp >> 7) & 0x1 !== 1`

First of all this is wrong, `0x1 !== 1` has a priority over the `&` so this is always false and the error never occurs. I think here we are checking the forbidden bit which is the first bit of the byte and must always be 0. So we need `(byte >> 7 & 1) !== 0` to trigger the error (or perhaps `== 1`)