### PR TITLE
Handle boxes with no type.

### DIFF
--- a/test/ui-helper.js
+++ b/test/ui-helper.js
@@ -241,7 +241,16 @@ function createFancyTree(parent, fileobj) {
 	fancytree_options.renderTitle = function(event, data) {
 		var box = data.node.data.box;
 		var el = "<span class='fancytree-title'>";
-		el += box.type + '&nbsp;';
+		var title = box.type;
+		if (!title) {
+			// Find index in parent.
+			var siblings = data.node.parent.children;
+			for (var idx = 0; idx < siblings.length; idx++) {
+				if (siblings[idx] == data.node) break;
+			}
+			title = idx;
+		}
+		el += title + '&nbsp;';
 		if (box.box_name)
 			el += "<span class='boxname'>(" + box.box_name + ")</span>";
 		el += "</span>";


### PR DESCRIPTION
Show the box's index instead of "undefined" (regression from commit 92eb110).