### PR TITLE
GIMI: uuid ItemContentID

### DIFF
--- a/src/parsing/uuid/gimi/gimiItemContentID.js
+++ b/src/parsing/uuid/gimi/gimiItemContentID.js
@@ -1,0 +1,4 @@
+BoxParser.createUUIDBox("261ef3741d975bbaacbd9d2c8ea73522", "ItemContentIDProperty", false, false, function(stream) {
+	this.content_id = stream.readCString();
+});
+


### PR DESCRIPTION
The `ItemContentIDProperty` UUID box is defined in the GIMI profile (see NGA.STND.0076 v1.0).

```C++
aligned(8) class ItemContentIDProperty
extends ItemProperty('uuid',0x261ef3741d975bbaacbd9d2c8ea73522) {
  utf8string ItemContentID;
}
```