### PR TITLE
fix: parse cslg version 1 box

### DIFF
--- a/src/DataStream.ts
+++ b/src/DataStream.ts
@@ -945,6 +945,23 @@ export class DataStream {
   }
 
   /**
+   * Writes a 64-bit int to the DataStream with the desired endianness.
+   *
+   * @param value Number to write.
+   * @param endianness Endianness of the number.
+   * @bundle DataStream-write.js
+   */
+  writeInt64(value: number, endianness?: boolean | null) {
+    this._realloc(8);
+    this._dataView.setBigInt64(
+      this.position,
+      BigInt(value),
+      endianness == null ? this.endianness : endianness,
+    );
+    this.position += 8;
+  }
+
+  /**
    * Writes a 32-bit int to the DataStream with the desired endianness.
    *
    * @param value Number to write.

--- a/src/boxes/cslg.ts
+++ b/src/boxes/cslg.ts
@@ -1,6 +1,8 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
 
+const INT32_MAX = 2_147_483_647;
+
 export class cslgBox extends FullBox {
   type = 'cslg' as const;
   box_name = 'CompositionToDecodeBox';
@@ -19,19 +21,42 @@ export class cslgBox extends FullBox {
       this.greatestDecodeToDisplayDelta = stream.readInt32(); /* signed */
       this.compositionStartTime = stream.readInt32(); /* signed */
       this.compositionEndTime = stream.readInt32(); /* signed */
+    } else if (this.version === 1) {
+      this.compositionToDTSShift = stream.readInt64(); /* signed */
+      this.leastDecodeToDisplayDelta = stream.readInt64(); /* signed */
+      this.greatestDecodeToDisplayDelta = stream.readInt64(); /* signed */
+      this.compositionStartTime = stream.readInt64(); /* signed */
+      this.compositionEndTime = stream.readInt64(); /* signed */
     }
   }
 
   /** @bundle writing/cslg.js */
   write(stream: MultiBufferStream) {
     this.version = 0;
+    if ((this.compositionToDTSShift > INT32_MAX) ||
+      (this.leastDecodeToDisplayDelta > INT32_MAX) ||
+      (this.greatestDecodeToDisplayDelta > INT32_MAX) ||
+      (this.compositionStartTime > INT32_MAX) ||
+      (this.compositionEndTime > INT32_MAX)) {
+      this.version = 1;
+    }
     this.flags = 0;
-    this.size = 4 * 5;
-    this.writeHeader(stream);
-    stream.writeInt32(this.compositionToDTSShift);
-    stream.writeInt32(this.leastDecodeToDisplayDelta);
-    stream.writeInt32(this.greatestDecodeToDisplayDelta);
-    stream.writeInt32(this.compositionStartTime);
-    stream.writeInt32(this.compositionEndTime);
+    if (this.version === 0) {
+      this.size = 4 * 5;
+      this.writeHeader(stream);
+      stream.writeInt32(this.compositionToDTSShift);
+      stream.writeInt32(this.leastDecodeToDisplayDelta);
+      stream.writeInt32(this.greatestDecodeToDisplayDelta);
+      stream.writeInt32(this.compositionStartTime);
+      stream.writeInt32(this.compositionEndTime);
+    } else if (this.version === 1) {
+      this.size = 8 * 5;
+      this.writeHeader(stream);
+      stream.writeInt64(this.compositionToDTSShift);
+      stream.writeInt64(this.leastDecodeToDisplayDelta);
+      stream.writeInt64(this.greatestDecodeToDisplayDelta);
+      stream.writeInt64(this.compositionStartTime);
+      stream.writeInt64(this.compositionEndTime);
+    }
   }
 }


### PR DESCRIPTION
gstreamer muxing uses version 1 of cslg, which is currently ignored

For the syntax, see ISO/IEC 14496-12:2022 Section 8.6.1.4.