### PR TITLE
fix: husky command not found for installs

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,13 @@
+// Skip Husky install in production and CI
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
+  process.exit(0);
+}
+
+// Install Husky hooks
+console.log('Installing Husky...');
+const husky = (await import('husky')).default;
+const output = husky();
+
+if (output && output.length > 0) {
+  console.log(output);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "mp4box",
       "version": "0.0.0-development",
-      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dist"
   ],
   "scripts": {
-    "install": "husky || true",
+    "prepare": "node .husky/install.mjs",
     "build": "tsup",
     "circular": "dpdm -T ./entries/all.ts",
     "types": "tsc --noEmit --project tsconfig.json",


### PR DESCRIPTION
[1] https://github.com/typicode/husky/issues/914
[2] https://github.com/typicode/husky/issues/914#issuecomment-2145063108

### Description

fix: husky command not found for installs

cc @DenizUgur & @bigmistqke (introduced in #424)