### PR TITLE
Add support for HDR Vivid

### DIFF
--- a/src/parsing/lhvC.js
+++ b/src/parsing/lhvC.js
@@ -10,6 +10,29 @@ BoxParser.createBoxCtor("lhvC", function(stream) {
 	this.lengthSizeMinusOne = (tmp_byte & 0X3);
 
 	this.nalu_arrays = [];
+	this.nalu_arrays.toString = function () {
+		var str = "<table class='inner-table'>";
+		str += "<thead><tr><th>completeness</th><th>nalu_type</th><th>nalu_data</th></tr></thead>";
+		str += "<tbody>";
+
+		for (var i=0; i<this.length; i++) {
+			var nalu_array = this[i];
+			str += "<tr>";
+			str += "<td rowspan='"+nalu_array.length+"'>"+nalu_array.completeness+"</td>";
+			str += "<td rowspan='"+nalu_array.length+"'>"+nalu_array.nalu_type+"</td>";
+			for (var j=0; j<nalu_array.length; j++) {
+				var nalu = nalu_array[j];
+				if (j !== 0) str += "<tr>";
+				str += "<td>";
+				str += nalu.data.reduce(function(str, byte) {
+					return str + byte.toString(16).padStart(2, "0");
+				}, "0x");
+				str += "</td></tr>";
+			}
+		}
+		str += "</tbody></table>";
+		return str;
+	}
 	var numOfArrays = stream.readUint8();
 	for (i = 0; i < numOfArrays; i++) {
 		var nalu_array = [];

--- a/src/parsing/uncC.js
+++ b/src/parsing/uncC.js
@@ -1,6 +1,6 @@
 BoxParser.createFullBoxCtor("uncC", function(stream) {
     var i;
-    this.profile = stream.readUint32();
+    this.profile = stream.readString(4);
     if (this.version == 1) {
         // Nothing - just the profile
     } else if (this.version == 0) {

--- a/test/qunit-helper.js
+++ b/test/qunit-helper.js
@@ -1,6 +1,6 @@
 Log.setLogLevel(Log.error);
-var TIMEOUT_MS = 10000;
-var mediaTestBaseUrl = './';
+var TIMEOUT_MS = 30000;
+var mediaTestBaseUrl = 'https://download.tsi.telecom-paristech.fr/gpac/mp4box.js/';
 
 function getFileRange(url, start, end, callback) {
 	var xhr = new XMLHttpRequest();
@@ -12,7 +12,7 @@ function getFileRange(url, start, end, callback) {
 		xhr.setRequestHeader('Range', range);
 	}
 	Log.info("XHR", "Getting resource at "+url+(range ? " range: "+range : ""));
-	xhr.onreadystatechange = function (e) { 
+	xhr.onreadystatechange = function (e) {
 		var buffer;
 		if ((xhr.status == 200 || xhr.status == 206 || xhr.status == 304 || xhr.status == 416) && xhr.readyState == this.DONE) {
 			buffer = xhr.response;


### PR DESCRIPTION
Add MP4 box support for signalling video bitstreams containing T/UWA 005 HDR DMI (HDR Vivid) metadata.

Signalling specification is [T/UWA 005-2.1](https://uhd-world-association.com/wp-content/uploads/2024/10/UWA-6-TUWA-005.2-1-2022-HDR-Video-Technology-Part-2-1-Application-Guide-to-System-Integration.pdf).
