### PR TITLE
fix: Fix typos in the QT boxes

### DIFF
--- a/src/boxes/qt/tapt.ts
+++ b/src/boxes/qt/tapt.ts
@@ -7,8 +7,8 @@ export class taptBox extends ContainerBox {
   type = 'tapt' as const;
   box_name = 'TrackApertureModeDimensionsBox';
 
-  clef: Array<clefBox> = [];
-  prof: Array<profBox> = [];
-  enof: Array<enofBox> = [];
+  clefs: Array<clefBox> = [];
+  profs: Array<profBox> = [];
+  enofs: Array<enofBox> = [];
   subBoxNames = ['clef', 'prof', 'enof'] as const;
 }


### PR DESCRIPTION
These variable names should all have an 's' at the end due to the
way that subBoxes are referenced in the parser.

Here is the error:

```
Uncaught TypeError: this[(this.subBoxNames[this.subBoxNames.indexOf(...)] + "s")] is undefined
    parse box.ts:255
    M box.ts:546
    parse box.ts:246
    M box.ts:546
    parse box.ts:246
    M box.ts:546
    parse isofile.ts:319
    appendBuffer isofile.ts:415
    onparsedbuffer ui-helper.js:143
    onBlockRead ui-helper.js:148
[box.ts:255:49](file:///data/src/mp4box.js/src/box.ts)
    parse box.ts:255
    M box.ts:546
    parse box.ts:246
    M box.ts:546
    parse box.ts:246
    M box.ts:546
    parse isofile.ts:319
    appendBuffer isofile.ts:415
    onparsedbuffer ui-helper.js:143
    onBlockRead ui-helper.js:148
​```