### PR TITLE
fix: Fix error with missing this.boxes in tref box

### DIFF
--- a/src/boxes/tref.ts
+++ b/src/boxes/tref.ts
@@ -23,6 +23,8 @@ export class trefBox extends ContainerBox {
           box.parseDataAndRewind(stream);
         }
         box.parse(stream);
+        if (!this.boxes)
+          this.boxes = [];
         this.boxes.push(box);
       } else {
         return;


### PR DESCRIPTION
When parsing a tref box, no this.boxes has been instantiated resulting in an an error saying that .push() is undefined.
