### PR TITLE
fix: mark fileStart mandatory on MP4BoxBuffer

### DIFF
--- a/src/mp4boxbuffer.ts
+++ b/src/mp4boxbuffer.ts
@@ -1,4 +1,4 @@
 export class MP4BoxBuffer extends ArrayBuffer {
-  fileStart?: number;
+  fileStart: number;
   usedBytes?: number;
 }


### PR DESCRIPTION
title
[12d87f2.txt](https://github.com/user-attachments/files/20517143/12d87f2.txt)
[48e89d8.txt](https://github.com/user-attachments/files/20517139/48e89d8.txt)

It doesn't seem to be a problem (running `npm run types` provides the same output with `strict: true`)