### PR TITLE
Fix ISOFile `onError` callback to accept error argument

### DIFF
--- a/src/isofile.ts
+++ b/src/isofile.ts
@@ -179,7 +179,7 @@ export class ISOFile<TSegmentUser = unknown, TSampleUser = unknown> {
   /** Callback to call when samples are ready */
   onSamples: ((id: number, user: TSampleUser, samples: Array<Sample>) => void) | null = null;
   /** Callback to call when there is an error in the parsing or processing of samples */
-  onError: (() => void) | null = null;
+  onError: ((e: string) => void) | null = null;
 
   onItem?: (() => void) | null = null;
   /** Boolean indicating if the moov box run-length encoded tables of sample information have been processed */


### PR DESCRIPTION
# What’s changed
Updated the `onError` callback type signature to accept an error argument.

# Why
Previously, the callback did not declare any parameters, which caused issues when trying to pass error information. This fix aligns the callback signature with the documentation.
