### PR TITLE
Sample Entry: 'urim'

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "prepare": "node .husky/install.mjs",
     "build": "tsup",
+    "build-dev": "npx tsup --sourcemap --format esm --minify false",
     "circular": "dpdm -T ./entries/all.ts --tsconfig tsconfig.lib.json --exit-code circular:1",
     "types": "tsc --noEmit -p tsconfig.lib.json",
     "test": "vitest run",

--- a/src/boxes/sampleentries/sampleentry.ts
+++ b/src/boxes/sampleentries/sampleentry.ts
@@ -1,3 +1,4 @@
+import type { MultiBufferStream } from '#/buffer';
 import { av1CBox } from '#/boxes/av1C';
 import { avcCBox } from '#/boxes/avcC';
 import { sinfBox } from '#/boxes/defaults';
@@ -417,6 +418,19 @@ export class encmSampleEntry extends MetadataSampleEntry {
   subBoxNames = ['sinf'] as const;
 
   sinfs: Array<sinfBox> = [];
+}
+
+export class urimSampleEntry extends MetadataSampleEntry {
+  the_label: string;
+  init?: string;
+
+  static override readonly fourcc = 'urim' as const;
+
+  parse(stream: MultiBufferStream) {
+    this.parseHeader(stream);
+    this.the_label = stream.readCString();
+    // TODO: this.init = remaining bytes
+  }
 }
 
 // Restricted sample entries


### PR DESCRIPTION
### Description
Reads the `urim` Metadata Sample Entry.

See ISO/IEC 14496-12, Section 12.3.3.2

```C
aligned(8) class URIBox extends FullBox('uri ', version = 0, 0) {
  utf8string theURI;
}
```
```C
aligned(8) class URIInitBox
  extends FullBox('uriI', version = 0, 0) {
  unsigned int(8) uri_initialization_data[];
}
```
```C
class URIMetaSampleEntry() extends MetaDataSampleEntry ('urim') {
  URIbox the_label;
  URIInitBox init; // optional
}
```
