### PR TITLE
fix: add box(-like) names for sample entries

### DIFF
--- a/src/boxes/sampleentries/sampleentry.ts
+++ b/src/boxes/sampleentries/sampleentry.ts
@@ -45,18 +45,26 @@ class avcCSampleEntryBase extends VisualSampleEntry {
 // Sample entries inheriting from Audio and Video
 export class avc1SampleEntry extends avcCSampleEntryBase {
   static override readonly fourcc = 'avc1' as const;
+  // ISO/IEC 14496-15:2024 5.4.2.1.2
+  box_name = 'AVCSampleEntry' as const;
 }
 
 export class avc2SampleEntry extends avcCSampleEntryBase {
   static override readonly fourcc = 'avc2' as const;
+  // ISO/IEC 14496-15:2024 5.4.2.1.2
+  box_name = 'AVC2SampleEntry' as const;
 }
 
 export class avc3SampleEntry extends avcCSampleEntryBase {
   static override readonly fourcc = 'avc3' as const;
+  // ISO/IEC 14496-15:2024 5.4.2.1.2
+  box_name = 'AVCSampleEntry' as const;
 }
 
 export class avc4SampleEntry extends avcCSampleEntryBase {
   static override readonly fourcc = 'avc4' as const;
+  // ISO/IEC 14496-15:2024 5.4.2.1.2
+  box_name = 'AVC2SampleEntry' as const;
 }
 
 export class av01SampleEntry extends VisualSampleEntry {
@@ -64,6 +72,9 @@ export class av01SampleEntry extends VisualSampleEntry {
   av1Cs: Array<av1CBox>;
 
   static override readonly fourcc = 'av01' as const;
+
+  // AV1 Codec ISO Media File Format Binding v1.2.0 Section 2.2.3
+  box_name = 'AV1SampleEntry' as const;
 
   /** @bundle box-codecs.js */
   getCodec(): string {
@@ -154,6 +165,8 @@ class hvcCSampleEntryBase extends VisualSampleEntry {
 
 export class hvc1SampleEntry extends hvcCSampleEntryBase {
   static override readonly fourcc = 'hvc1' as const;
+  // ISO/IEC 14496-15:2024 8.4.1.1.2
+  box_name = 'HEVCSampleEntry' as const;
 }
 
 export class hvc2SampleEntry extends hvcCSampleEntryBase {
@@ -162,6 +175,8 @@ export class hvc2SampleEntry extends hvcCSampleEntryBase {
 
 export class hev1SampleEntry extends hvcCSampleEntryBase {
   static override readonly fourcc = 'hev1' as const;
+  // ISO/IEC 14496-15:2024 8.4.1.1.2
+  box_name = 'HEVCSampleEntry' as const;
   colrs: Array<colrBox> = [];
   subBoxNames = ['colr'] as const;
 }
@@ -172,14 +187,20 @@ export class hev2SampleEntry extends hvcCSampleEntryBase {
 
 export class hvt1SampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'hvt1' as const;
+  // ISO/IEC 14496-15:2024 10.5.2.2
+  box_name = 'HEVCTileSampleSampleEntry' as const;
 }
 
 export class lhe1SampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'lhe1' as const;
+  // ISO/IEC 14496-15:2024 9.5.3.1.2
+  box_name = 'LHEVCSampleEntry' as const;
 }
 
 export class lhv1SampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'lhv1' as const;
+  // ISO/IEC 14496-15:2024 9.5.3.1.2
+  box_name = 'LHEVCSampleEntry' as const;
 }
 
 export class dvh1SampleEntry extends VisualSampleEntry {
@@ -255,18 +276,26 @@ class vvcCSampleEntryBase extends VisualSampleEntry {
 
 export class vvc1SampleEntry extends vvcCSampleEntryBase {
   static override readonly fourcc = 'vvc1' as const;
+  // ISO/IEC 14496-15:2024 11.3.1.2
+  box_name = 'VvcSampleEntry' as const;
 }
 
 export class vvi1SampleEntry extends vvcCSampleEntryBase {
   static override readonly fourcc = 'vvi1' as const;
+  // ISO/IEC 14496-15:2024 11.3.1.2
+  box_name = 'VvcSampleEntry' as const;
 }
 
 export class vvs1SampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'vvs1' as const;
+  // ISO/IEC 14496-15:2024 11.3.1.2
+  box_name = 'VvcSampleEntry' as const;
 }
 
 export class vvcNSampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'vvcN' as const;
+  // ISO/IEC 14496-15:2024 11.3.3.1.2
+  box_name = 'VvcNonVCLSampleEntry' as const;
 }
 
 class vpcCSampleEntryBase extends VisualSampleEntry {
@@ -300,6 +329,8 @@ export class avs3SampleEntry extends VisualSampleEntry {
 
 export class j2kiSampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'j2ki' as const;
+  // ISO/IEC 15444-16:2021 Section 7.3
+  box_name = 'J2KSampleEntry' as const;
 }
 
 export class mjp2SampleEntry extends VisualSampleEntry {
@@ -312,14 +343,20 @@ export class mjpgSampleEntry extends VisualSampleEntry {
 
 export class uncvSampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'uncv' as const;
+  // ISO/IEC 23001-17:2024 4.2
+  box_name = 'UncompressedVideoSampleEntry' as const;
 }
 
 export class mp4vSampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'mp4v' as const;
+  // ISO/IEC 14496-14:2020 Section 6.7.3
+  box_name = 'MP4VisualSampleEntry' as const;
 }
 
 export class mp4aSampleEntry extends AudioSampleEntry {
   static override readonly fourcc = 'mp4a' as const;
+  // ISO/IEC 14496-14:2020 Section 6.7.3
+  box_name = 'MP4AudioSampleEntry' as const;
 
   esds: esdsBox;
   esdss: Array<esdsBox>;
@@ -422,4 +459,6 @@ export class encmSampleEntry extends MetadataSampleEntry {
 // Restricted sample entries
 export class resvSampleEntry extends VisualSampleEntry {
   static override readonly fourcc = 'resv' as const;
+  // ISO/IEC 14496-12:2022 Section 8.15
+  box_name = 'RestrictedVideoSampleEntry' as const;
 }


### PR DESCRIPTION
### Description

Adds display names for sample entries.

I use mp4box.js to display the file structure - https://gpac.github.io/mp4box.js/test/filereader.html or a local instance.

The box tree has names for most things, but not for sample entries. An example is shown below:

![image](https://github.com/user-attachments/assets/2208dab3-b76e-4b49-bd8a-98aef9f654a8)

AFAICT, there are not really "box names" for these SampleEntry instances, but there is a reasonable description on the MP4RA web site - https://mp4ra.org/registered-types/codecs

Some of those aren't great, but I tried to keep close to the terms used there, especially for codecs that aren't very common.