### PR TITLE
feat: add csch box

### DIFF
--- a/entries/all-boxes.ts
+++ b/entries/all-boxes.ts
@@ -15,6 +15,7 @@ export * from '#/boxes/co64';
 export * from '#/boxes/CoLL';
 export * from '#/boxes/colr';
 export * from '#/boxes/cprt';
+export * from '#/boxes/csch';
 export * from '#/boxes/cslg';
 export * from '#/boxes/ctts';
 export * from '#/boxes/dac3';

--- a/src/boxes/csch.ts
+++ b/src/boxes/csch.ts
@@ -1,0 +1,20 @@
+import { FullBox } from '#/box';
+import type { MultiBufferStream } from '#/buffer';
+
+export class cschBox extends FullBox {
+  static override readonly fourcc = 'csch' as const;
+  box_name = 'CompatibleSchemeTypeBox' as const;
+
+  scheme_type: string;
+  scheme_version: number;
+  scheme_uri: string;
+
+  parse(stream: MultiBufferStream) {
+    this.parseFullHeader(stream);
+    this.scheme_type = stream.readString(4);
+    this.scheme_version = stream.readUint32();
+    if (this.flags & 0x000001) {
+      this.scheme_uri = stream.readCString();
+    }
+  }
+}


### PR DESCRIPTION
The CompatibleSchemeTypeBox (`csch`) identifies the scheme type that the track belongs to.

See ISO/IEC 14496-12:2022 Section 8.15.5

This is used for restricted video, for example OMAF -  Garage_qp28.mp4 as a specific example.