### PR TITLE
feat: add prfr box and povd container

### DIFF
--- a/entries/all-boxes.ts
+++ b/entries/all-boxes.ts
@@ -70,6 +70,7 @@ export * from '#/boxes/pitm';
 export * from '#/boxes/pixi';
 export * from '#/boxes/pmax';
 export * from '#/boxes/prdi';
+export * from '#/boxes/prfr';
 export * from '#/boxes/prft';
 export * from '#/boxes/pssh';
 export * from '#/boxes/qt/clef';

--- a/src/boxes/defaults.ts
+++ b/src/boxes/defaults.ts
@@ -359,3 +359,8 @@ export class etypBox extends ContainerBox {
   tycos: Array<tycoBox> = [];
   subBoxNames = ['tyco'] as const;
 }
+export class povdBox extends ContainerBox {
+  static override readonly fourcc = 'povd' as const;
+  box_name = 'ProjectedOmniVideoBox' as const;
+  subBoxNames = ['prfr'] as const;
+}

--- a/src/boxes/prfr.ts
+++ b/src/boxes/prfr.ts
@@ -1,0 +1,14 @@
+import { FullBox } from '#/box';
+import type { MultiBufferStream } from '#/buffer';
+
+export class prfrBox extends FullBox {
+  static override readonly fourcc = 'prfr' as const;
+  box_name = 'ProjectionFormatBox' as const;
+
+  projection_type: number;
+
+  parse(stream: MultiBufferStream) {
+    this.parseFullHeader(stream);
+    this.projection_type = stream.readUint8() & 0b00011111;
+  }
+}


### PR DESCRIPTION
`prfr` is the OMAF ProjectionFormatBox, which is nested within the `povd` container. See ISO/IEC 23090-2:2023 Section 7.6.2.2 for both.

There is an image property for `prfr`, which is the same syntax, but is nested within `ipco` instead. See ISO/IEC 23090-2:2023 Section 7.9.3.2.


