### PR TITLE
feat: add text item reference type

### DIFF
--- a/src/boxes/iref.ts
+++ b/src/boxes/iref.ts
@@ -21,6 +21,7 @@ const REFERENCE_TYPE_NAMES = {
   pred: 'Predictively coded item',
   prem: 'Pre-multiplied item',
   tbas: 'HEVC tile track base item',
+  text: 'Text item',
   thmb: 'Thumbnail image item',
 };
 
@@ -45,6 +46,7 @@ export class irefBox extends FullBox {
     'pred',
     'prem',
     'tbas',
+    'text',
     'thmb',
   ] as const;
 


### PR DESCRIPTION
This is from ISO/IEC 23008-12:2025 (i.e. third edition), Section 6.10.1.1.

Text items use an item reference of type `text` from the text item to the image item.

Sample file (self-generated,  not valid in general, but shows the relationship):
[text.heif.gz](https://github.com/user-attachments/files/21201903/text.heif.gz)

Screenshot:
<img width="3022" height="1205" alt="image" src="https://github.com/user-attachments/assets/b0890bde-ba19-439c-8751-f53ded9197c6" />
