### PR TITLE
Fix AVCC write() endianness

### DIFF
--- a/src/boxes/avcC.ts
+++ b/src/boxes/avcC.ts
@@ -1,6 +1,6 @@
 import { Box } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { DataStream } from '#/DataStream';
+import { DataStream, Endianness } from '#/DataStream';
 import { MP4BoxStream } from '#/stream';
 import { ParameterSetArray } from './displays/parameterSetArray';
 
@@ -66,12 +66,12 @@ export class avcCBox extends Box {
     stream.writeUint8(this.lengthSizeMinusOne + (63 << 2));
     stream.writeUint8(this.SPS.length + (7 << 5));
     for (let i = 0; i < this.SPS.length; i++) {
-      stream.writeUint16(this.SPS[i].length);
+      stream.writeUint16(this.SPS[i].length, Endianness.BIG_ENDIAN);
       stream.writeUint8Array(this.SPS[i].data);
     }
     stream.writeUint8(this.PPS.length);
     for (let i = 0; i < this.PPS.length; i++) {
-      stream.writeUint16(this.PPS[i].length);
+      stream.writeUint16(this.PPS[i].length, Endianness.BIG_ENDIAN);
       stream.writeUint8Array(this.PPS[i].data);
     }
     if (this.ext) {

--- a/src/isofile.ts
+++ b/src/isofile.ts
@@ -1876,6 +1876,7 @@ export class ISOFile<TSegmentUser = unknown, TSampleUser = unknown> {
       } else {
         // We might have already transferred the sample data to mdat
         for (const mdat of this.mdats) {
+          if (!mdat.stream) continue;
           index = mdat.stream.findPosition(
             true,
             sample.offset + sample.alreadyRead - mdat.start - mdat.hdr_size,


### PR DESCRIPTION
### Description

<!-- Please describe your changes in detail. Include motivation and context. -->

<!------------------------------------------------------------------------------
If you are contributing a new box or fixing an issue, please provide references
to the relevant specifications, documentation, or issues. This helps maintainers
get familiar with the context of your changes.

Thank you for your contribution!
-------------------------------------------------------------------------------->
The current version of the AVCC box's write() function is incorrect. The SPS and PPS length fields **must** be big endian, not machine endian (which is usually little endian). Otherwise, APIs (e.g. WebCodecs) refuse to parse it.

Also, I added a check for the mdat stream not to be null because it can sometimes cause exceptions, like below:
<img width="605" height="93" alt="Screenshot 2025-07-14 at 01 38 23" src="https://github.com/user-attachments/assets/123e8172-fb83-401a-818f-dc80fc95d2b8" />