### PR TITLE
fix: fromArrayBuffer return a MP4BoxBuffer

### DIFF
--- a/src/mp4boxbuffer.ts
+++ b/src/mp4boxbuffer.ts
@@ -9,9 +9,16 @@ export class MP4BoxBuffer extends ArrayBuffer {
   }
 
   static fromArrayBuffer(buffer: ArrayBuffer, fileStart: number): MP4BoxBuffer {
-    const mp4BoxBuffer = buffer as MP4BoxBuffer;
+    const mp4BoxBuffer = new MP4BoxBuffer(buffer.byteLength);
+
+    const targetView = new Uint8Array(mp4BoxBuffer);
+    const sourceView = new Uint8Array(buffer);
+
+    targetView.set(sourceView);
+
     mp4BoxBuffer.fileStart = fileStart;
     mp4BoxBuffer.usedBytes = 0;
+
     return mp4BoxBuffer;
   }
 }


### PR DESCRIPTION
This allows users to use `obj instanceof MP4BoxBuffer` after `const obj = MP4BoxBuffer.fromArrayBuffer(...)`

Btw this should reuse the underlying source `buffer` as specified in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set#typedarray