### PR TITLE
fix: off by one errors in box and field size calculations

### DIFF
--- a/src/box.ts
+++ b/src/box.ts
@@ -4,7 +4,7 @@
  */
 
 import { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 import { DataStream, Endianness } from '#/DataStream';
 import { Log } from '#/log';
 import { MP4BoxStream } from '#/stream';
@@ -71,7 +71,7 @@ export class Box {
   /** @bundle box-write.js */
   writeHeader(stream: DataStream, msg?: string) {
     this.size += 8;
-    if (this.size > MAX_SIZE || this.original_size === 1) {
+    if (this.size > MAX_UINT32 || this.original_size === 1) {
       this.size += 8;
     }
     if (this.type === 'uuid') {
@@ -89,7 +89,7 @@ export class Box {
     );
     if (this.original_size === 0) {
       stream.writeUint32(0);
-    } else if (this.size > MAX_SIZE || this.original_size === 1) {
+    } else if (this.size > MAX_UINT32 || this.original_size === 1) {
       stream.writeUint32(1);
     } else {
       this.sizePosition = stream.getPosition();
@@ -103,7 +103,7 @@ export class Box {
       }
       stream.writeUint8Array(uuidBytes);
     }
-    if (this.size > MAX_SIZE || this.original_size === 1) {
+    if (this.size > MAX_UINT32 || this.original_size === 1) {
       this.sizePosition = stream.getPosition();
       stream.writeUint64(this.size);
     }
@@ -137,7 +137,7 @@ export class Box {
   /** @bundle box-print.js */
   printHeader(output: Output) {
     this.size += 8;
-    if (this.size > MAX_SIZE) {
+    if (this.size > MAX_UINT32) {
       this.size += 8;
     }
     if (this.type === 'uuid') {

--- a/src/boxes/elst.ts
+++ b/src/boxes/elst.ts
@@ -36,7 +36,6 @@ export class elstBox extends FullBox {
     this.size += useVersion1 ? 2 * 4 * this.entries.length : 0;
 
     this.writeHeader(stream);
-
     stream.writeUint32(this.entries.length);
     for (let i = 0; i < this.entries.length; i++) {
       const entry = this.entries[i];

--- a/src/boxes/elst.ts
+++ b/src/boxes/elst.ts
@@ -1,6 +1,7 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
 import type { Entry } from '@types';
+import { MAX_UINT32 } from '#/constants';
 
 export class elstBox extends FullBox {
   static override readonly fourcc = 'elst' as const;
@@ -25,12 +26,21 @@ export class elstBox extends FullBox {
 
   /** @bundle writing/elst.js */
   write(stream: MultiBufferStream) {
+    const useVersion1 =
+      this.entries.some(
+        entry => entry.segment_duration > MAX_UINT32 || entry.media_time > MAX_UINT32,
+      ) || this.version === 1;
+    this.version = useVersion1 ? 1 : 0;
+
     this.size = 4 + 12 * this.entries.length;
+    this.size += useVersion1 ? 2 * 4 * this.entries.length : 0;
+
     this.writeHeader(stream);
+
     stream.writeUint32(this.entries.length);
     for (let i = 0; i < this.entries.length; i++) {
       const entry = this.entries[i];
-      if (this.version === 1) {
+      if (useVersion1) {
         stream.writeUint64(entry.segment_duration);
         stream.writeInt64(entry.media_time);
       } else {

--- a/src/boxes/mdhd.ts
+++ b/src/boxes/mdhd.ts
@@ -1,6 +1,6 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 
 export class mdhdBox extends FullBox {
   static override readonly fourcc = 'mdhd' as const;
@@ -31,9 +31,9 @@ export class mdhdBox extends FullBox {
   /** @bundle writing/mdhd.js */
   write(stream: MultiBufferStream) {
     const useVersion1 =
-      this.modification_time > MAX_SIZE ||
-      this.creation_time > MAX_SIZE ||
-      this.duration > MAX_SIZE ||
+      this.modification_time > MAX_UINT32 ||
+      this.creation_time > MAX_UINT32 ||
+      this.duration > MAX_UINT32 ||
       this.version === 1;
     this.version = useVersion1 ? 1 : 0;
 

--- a/src/boxes/mehd.ts
+++ b/src/boxes/mehd.ts
@@ -1,7 +1,7 @@
 import { Log } from '#//log';
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 
 export class mehdBox extends FullBox {
   static override readonly fourcc = 'mehd' as const;
@@ -24,7 +24,7 @@ export class mehdBox extends FullBox {
 
   /** @bundle writing/mehd.js */
   write(stream: MultiBufferStream) {
-    const useVersion1 = this.fragment_duration > MAX_SIZE || this.version === 1;
+    const useVersion1 = this.fragment_duration > MAX_UINT32 || this.version === 1;
     this.version = useVersion1 ? 1 : 0;
 
     this.size = 4;

--- a/src/boxes/mvhd.ts
+++ b/src/boxes/mvhd.ts
@@ -1,6 +1,6 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 import type { Matrix, Output } from '@types';
 
 export class mvhdBox extends FullBox {
@@ -33,7 +33,7 @@ export class mvhdBox extends FullBox {
     this.volume = stream.readUint16() >> 8;
     stream.readUint16();
     stream.readUint32Array(2);
-    this.matrix = stream.readUint32Array(9);
+    this.matrix = stream.readInt32Array(9);
     stream.readUint32Array(6);
     this.next_track_id = stream.readUint32();
   }
@@ -41,9 +41,9 @@ export class mvhdBox extends FullBox {
   /** @bundle writing/mvhd.js */
   write(stream: MultiBufferStream) {
     const useVersion1 =
-      this.modification_time > MAX_SIZE ||
-      this.creation_time > MAX_SIZE ||
-      this.duration > MAX_SIZE ||
+      this.modification_time > MAX_UINT32 ||
+      this.creation_time > MAX_UINT32 ||
+      this.duration > MAX_UINT32 ||
       this.version === 1;
     this.version = useVersion1 ? 1 : 0;
 
@@ -69,7 +69,7 @@ export class mvhdBox extends FullBox {
     stream.writeUint16(0);
     stream.writeUint32(0);
     stream.writeUint32(0);
-    stream.writeUint32Array(this.matrix);
+    stream.writeInt32Array(this.matrix);
     stream.writeUint32(0);
     stream.writeUint32(0);
     stream.writeUint32(0);

--- a/src/boxes/mvhd.ts
+++ b/src/boxes/mvhd.ts
@@ -33,7 +33,7 @@ export class mvhdBox extends FullBox {
     this.volume = stream.readUint16() >> 8;
     stream.readUint16();
     stream.readUint32Array(2);
-    this.matrix = stream.readInt32Array(9);
+    this.matrix = stream.readUint32Array(9);
     stream.readUint32Array(6);
     this.next_track_id = stream.readUint32();
   }
@@ -69,7 +69,7 @@ export class mvhdBox extends FullBox {
     stream.writeUint16(0);
     stream.writeUint32(0);
     stream.writeUint32(0);
-    stream.writeInt32Array(this.matrix);
+    stream.writeUint32Array(this.matrix);
     stream.writeUint32(0);
     stream.writeUint32(0);
     stream.writeUint32(0);

--- a/src/boxes/sidx.ts
+++ b/src/boxes/sidx.ts
@@ -1,6 +1,6 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 
 interface Reference {
   reference_type: number;
@@ -59,8 +59,8 @@ export class sidxBox extends FullBox {
   /** @bundle writing/sidx.js */
   write(stream: MultiBufferStream) {
     const useVersion1 =
-      this.earliest_presentation_time > MAX_SIZE ||
-      this.first_offset > MAX_SIZE ||
+      this.earliest_presentation_time > MAX_UINT32 ||
+      this.first_offset > MAX_UINT32 ||
       this.version === 1;
     this.version = useVersion1 ? 1 : 0;
 

--- a/src/boxes/tfdt.ts
+++ b/src/boxes/tfdt.ts
@@ -28,7 +28,6 @@ export class tfdtBox extends FullBox {
 
     this.flags = 0;
     this.writeHeader(stream);
-
     if (useVersion1) {
       stream.writeUint64(this.baseMediaDecodeTime);
     } else {

--- a/src/boxes/tfdt.ts
+++ b/src/boxes/tfdt.ts
@@ -1,6 +1,6 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 
 export class tfdtBox extends FullBox {
   static override readonly fourcc = 'tfdt' as const;
@@ -20,14 +20,16 @@ export class tfdtBox extends FullBox {
   /** @bundle writing/tdft.js */
   write(stream: MultiBufferStream) {
     // use version 1 if baseMediaDecodeTime does not fit 32 bits
-    this.version = this.baseMediaDecodeTime > MAX_SIZE || this.version === 1 ? 1 : 0;
-    this.flags = 0;
+    const useVersion1 = this.baseMediaDecodeTime > MAX_UINT32 || this.version === 1;
+    this.version = useVersion1 ? 1 : 0;
+
     this.size = 4;
-    if (this.version === 1) {
-      this.size += 4;
-    }
+    this.size += useVersion1 ? 4 : 0;
+
+    this.flags = 0;
     this.writeHeader(stream);
-    if (this.version === 1) {
+
+    if (useVersion1) {
       stream.writeUint64(this.baseMediaDecodeTime);
     } else {
       stream.writeUint32(this.baseMediaDecodeTime);

--- a/src/boxes/tkhd.ts
+++ b/src/boxes/tkhd.ts
@@ -1,6 +1,6 @@
 import { FullBox } from '#/box';
 import type { MultiBufferStream } from '#/buffer';
-import { MAX_SIZE } from '#/constants';
+import { MAX_UINT32 } from '#/constants';
 import type { Matrix } from '@types';
 
 export class tkhdBox extends FullBox {
@@ -45,9 +45,9 @@ export class tkhdBox extends FullBox {
 
   write(stream: MultiBufferStream) {
     const useVersion1 =
-      this.modification_time > MAX_SIZE ||
-      this.creation_time > MAX_SIZE ||
-      this.duration > MAX_SIZE ||
+      this.modification_time > MAX_UINT32 ||
+      this.creation_time > MAX_UINT32 ||
+      this.duration > MAX_UINT32 ||
       this.version === 1;
     this.version = useVersion1 ? 1 : 0;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,4 @@
 export const MAX_SIZE = Math.pow(2, 32);
-
 export const MAX_UINT32 = Math.pow(2, 32) - 1;
 
 // Flags

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export const MAX_SIZE = Math.pow(2, 32);
 
+export const MAX_UINT32 = Math.pow(2, 32) - 1;
+
 // Flags
 export const TKHD_FLAG_ENABLED = 0x000001;
 export const TKHD_FLAG_IN_MOVIE = 0x000002;


### PR DESCRIPTION
Consider the following test. It will fail because there is an off-by-one error in the calculation of the field size needed to store baseMediaDecodeTime. There are a bunch of these, including in the base Box size calculation. Seems to have been introduced in the TS rewrite.

```
describe('tfdtBox', () => {
	it('writes a version 1 box when presented with a baseMediaDecodeTime > 32 bits', () => {
		const smallest_thirtythree_bit_number = Math.pow(2, 32);

		const tfdt = new tfdtBox();
		tfdt.baseMediaDecodeTime = smallest_thirtythree_bit_number;

		const stream = new MultiBufferStream();
        tfdt.write(stream);

		const expected = new Uint8Array([
			0x00, 0x00, 0x00, 0x14, // size (20 bytes)
			0x74, 0x66, 0x64, 0x74, // type 'tfdt'
			0x01,                   // version 1
			0x00, 0x00, 0x00,       // flags
			0x00, 0x00, 0x00, 0x01, // baseMediaDecodeTime (upper 4 bytes)
			0x00, 0x00, 0x00, 0x00  // baseMediaDecodeTime (lower 4 bytes)
		]);

		assert.deepStrictEqual(new Uint8Array(stream.buffer), expected);
	});
});
```