### PR TITLE
fix: trakBox reported edts to always be present

### DIFF
--- a/src/boxes/defaults.ts
+++ b/src/boxes/defaults.ts
@@ -156,7 +156,7 @@ export class trakBox extends ContainerBox {
 export class edtsBox extends ContainerBox {
   static override readonly fourcc = 'edts' as const;
   box_name = 'EditBox' as const;
-  elst: elstBox;
+  elst?: elstBox;
   elsts: Array<elstBox>;
 }
 export class mdiaBox extends ContainerBox {

--- a/src/isofile.ts
+++ b/src/isofile.ts
@@ -687,7 +687,7 @@ export class ISOFile<TSegmentUser = unknown, TSampleUser = unknown> {
         }
       }
 
-      if (trak.edts) {
+      if (trak.edts !== undefined && trak.edts.elst !== undefined) {
         track.edits = trak.edts.elst.entries;
       }
 


### PR DESCRIPTION
Few files to test:

- No elst but have edts 

https://github.com/user-attachments/assets/a6f0f796-c7e4-4482-8bac-99600429c4a1

- No elst no edts

https://github.com/user-attachments/assets/737cc95a-b28a-43a8-b326-dbbcd4230421

- elst with 0 entries

https://github.com/user-attachments/assets/97c9cd07-3d29-4ff7-9f5f-bd5a0bd13de1

- elst with 2 entries

https://github.com/user-attachments/assets/ffb4c88c-cda9-46fd-8579-bed6fa96b820

- elst with 1 entry

https://github.com/user-attachments/assets/d37f7fee-3a4d-48c4-a0f9-2e4f2e306e96

