### PR TITLE
chore: updated demo links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ npm install mp4box@latest
 
 ## Demos
 
-- [A player that performs on-the-fly fragmentation](./test/index.html)
-- [A file inspection tool](./test/filereader.html)
-- [A basic file segmenter](./test/file-segmenter.html)
-- [A file diff tool](./test/filediff.html)
-- [An MSE-based AVIF viewing tool](./test/mse-avif-viewer.html)
-- [QUnit tests](./test/qunit.html)
+- [A player that performs on-the-fly fragmentation](./demo/index.html)
+- [A file inspection tool](./demo/filereader.html)
+- [A basic file segmenter](./demo/file-segmenter.html)
+- [A file diff tool](./demo/filediff.html)
+- [An MSE-based AVIF viewing tool](./demo/mse-avif-viewer.html)
 
 ## API
 


### PR DESCRIPTION
Updated demo links to point to the correct directory.

### Description

<!-- Please describe your changes in detail. Include motivation and context. -->
I noticed the links to the demos weren't working, so I changed them where the files appear to have been relocated. It seems that the files were moved to demo in commit 6dc21caf81fd29627e595bafc83b607a8d9494ba but the links weren't updated. qunit.html seems to also have been removed in b14e12d513e629eb347c2862d1abe03e1a259ea6.

<!------------------------------------------------------------------------------
If you are contributing a new box or fixing an issue, please provide references
to the relevant specifications, documentation, or issues. This helps maintainers
get familiar with the context of your changes.

Thank you for your contribution!
-------------------------------------------------------------------------------->
