### PR TITLE
feat: add srat box

### DIFF
--- a/entries/all-boxes.ts
+++ b/entries/all-boxes.ts
@@ -97,6 +97,7 @@ export * from '#/boxes/sgpd';
 export * from '#/boxes/sidx';
 export * from '#/boxes/SmDm';
 export * from '#/boxes/smhd';
+export * from '#/boxes/srat';
 export * from '#/boxes/ssix';
 export * from '#/boxes/stco';
 export * from '#/boxes/stdp';

--- a/src/boxes/srat.ts
+++ b/src/boxes/srat.ts
@@ -1,0 +1,14 @@
+import { FullBox } from '#/box';
+import type { MultiBufferStream } from '#/buffer';
+
+export class sratBox extends FullBox {
+  static override readonly fourcc = 'srat' as const;
+  box_name = 'SamplingRateBox' as const;
+
+  sampling_rate: number;
+
+  parse(stream: MultiBufferStream) {
+    this.parseFullHeader(stream);
+    this.sampling_rate = stream.readUint32();
+  }
+}


### PR DESCRIPTION
The `SamplingRateBox` is used to indicate an audio sampling rate greater than the value that can be represented in the AudioSampleEntry's samplerate field.

See ISO/IEC 14496-12:2022 Section 12.2.3.1