### PR TITLE
Fix: Prevent crash in initializeSegmentation when 'mehd' box is missing

### DIFF
--- a/src/isofile.ts
+++ b/src/isofile.ts
@@ -1306,7 +1306,7 @@ export class ISOFile<TSegmentUser = unknown, TSampleUser = unknown> {
       buffer: ISOFile.writeInitializationSegment(
         this.ftyp,
         moov,
-        this.moov?.mvex?.mehd.fragment_duration,
+        this.moov?.mvex?.mehd?.fragment_duration,
       ),
     };
   }


### PR DESCRIPTION
### Description

I recently upgraded mp4box from v0.5.3 to v2.3.0. I am processing a fragmented MP4 file (generated via Chrome's MediaRecorder) in a streaming format (appending chunks from disk).

When calling `initializeSegmentation()` the library crashes with a `TypeError`.

```
TypeError: Cannot read properties of undefined (reading 'fragment_duration')
    at _ISOFile.writeInitializationSegment (mp4box.all.js:xxxx)
    at _ISOFile.initializeSegmentation (mp4box.all.js:xxxx)
```

The video file is a valid fragmented MP4 (`isFragmented: true`). However, since it is generated by a live recorder it does not contain the optional `mehd` box within `mvex`.

Here is the minimal code I am using in the client:

```
const mp4box = MP4Box.createFile();

mp4box.onReady = (info) => {
  for (const track of info.tracks) {
    mp4box.setSegmentOptions(track.id, userSourceBuffer, { nbSamples: 100 });
  }
  
  const initSegments = mp4box.initializeSegmentation();   // It is crashing in v2.3.0
};

// ...
arrayBuffer.fileStart = chunkOffset;
mp4box.appendBuffer(arrayBuffer);
```

### Root cause:
I investigated the source code for v2.3.0. The issue seems to be in `ISOFile.writeInitializationSegment` ([here](https://github.com/gpac/mp4box.js/blob/main/src/isofile.ts#L1306) - introduced in [this commit](https://github.com/gpac/mp4box.js/commit/77247e16b41282b7fcfb20482a9cf217350b71de#diff-60cfe397e0e84e7fccb06c8dba3d843f62355eb2cf94b54756bb93cbcd6aad8fR1269)). 

The code tries to access `fragment_duration` from the `mehd` box without verifying if the `mehd` box actually exists. While `moov` and `mvex` are checked (or exist), `mehd` is optional in the spec and missing in my file.


### Testing
I have applied this patch locally and it resolves the crash allowing `initializeSegmentation()` to proceed correctly with my fragmented files.