### PR TITLE
feat: add per-track segmentation init mode

### DIFF
--- a/.changeset/kind-turtles-dance.md
+++ b/.changeset/kind-turtles-dance.md
@@ -1,0 +1,5 @@
+---
+"mp4box": minor
+---
+
+feat: add per-track initialization segments for segmentation

--- a/README.md
+++ b/README.md
@@ -270,28 +270,29 @@ mp4boxfile.onSegment = function (id, user, buffer, sampleNumber, last) {
 };
 ```
 
-#### initializeSegmentation()
+#### initializeSegmentation(mode)
 
-Indicates that the application is ready to receive segments. Returns an array of objects containing the following properties:
+Indicates that the application is ready to receive segments.
+`mode` can be `'combined'` (default) or `'per-track'`.
 
-- **id**: Number, the track id
-- **user**: Object, the caller of the segmentation for this track, as given in [setSegmentOptions](##setsegmentoptionstrack_id-user-options)
-- **buffer**: ArrayBuffer, the initialization segment for this track.
-- **sampleNumber**: Number, sample number of the last sample in the segment, plus 1.
-- **last**: Boolean, indication if this is the last segment to be received.
+By default, it returns a single initialization segment containing all tracks configured with [setSegmentOptions](#setsegmentoptionstrack_id-user-options):
+
+```json
+{
+  "tracks": [
+    { "id": 2, "user": "[SourceBuffer]" },
+    { "id": 3, "user": "[SourceBuffer]" }
+  ],
+  "buffer": "[ArrayBuffer]"
+}
+```
+
+If called with `'per-track'`, it returns one initialization segment per fragmented track:
 
 ```json
 [
-  {
-    "id": 2,
-    "buffer": "[ArrayBuffer]",
-    "user": "[SourceBuffer]"
-  },
-  {
-    "id": 3,
-    "buffer": "[ArrayBuffer]",
-    "user": "[SourceBuffer]"
-  }
+  { "id": 2, "buffer": "[ArrayBuffer]", "user": "[SourceBuffer]" },
+  { "id": 3, "buffer": "[ArrayBuffer]", "user": "[SourceBuffer]" }
 ]
 ```
 

--- a/entries/types.ts
+++ b/entries/types.ts
@@ -119,6 +119,23 @@ export interface FragmentedTrack<TUser> {
     accumulatedSize: number;
   };
 }
+
+export interface SegmentationInitializationTrack<TUser> {
+  id: number;
+  user: TUser;
+}
+
+export interface SegmentationInitialization<TUser> {
+  tracks: Array<SegmentationInitializationTrack<TUser>>;
+  buffer: ArrayBuffer;
+}
+
+export interface SegmentationInitializationPerTrack<
+  TUser,
+> extends SegmentationInitializationTrack<TUser> {
+  buffer: ArrayBuffer;
+}
+
 export interface ExtractedTrack<TUser> {
   id: number;
   user: TUser;

--- a/entries/types.ts
+++ b/entries/types.ts
@@ -119,6 +119,22 @@ export interface FragmentedTrack<TUser> {
     accumulatedSize: number;
   };
 }
+
+export interface SegmentationInitializationTrack<TUser> {
+  id: number;
+  user: TUser;
+}
+
+export interface SegmentationInitialization<TUser> {
+  tracks: Array<SegmentationInitializationTrack<TUser>>;
+  buffer: ArrayBuffer;
+}
+
+export interface SegmentationInitializationPerTrack<TUser>
+  extends SegmentationInitializationTrack<TUser> {
+  buffer: ArrayBuffer;
+}
+
 export interface ExtractedTrack<TUser> {
   id: number;
   user: TUser;

--- a/src/isofile.ts
+++ b/src/isofile.ts
@@ -93,6 +93,8 @@ import type {
   Item,
   Movie,
   Output,
+  SegmentationInitialization,
+  SegmentationInitializationPerTrack,
   Sample,
   SampleEntryFourCC,
   SubSample,
@@ -1303,42 +1305,65 @@ export class ISOFile<TSegmentUser = unknown, TSampleUser = unknown> {
   }
 
   /** @bundle isofile-write.js */
-  initializeSegmentation() {
+  initializeSegmentation(mode?: 'combined'): SegmentationInitialization<TSegmentUser>;
+  initializeSegmentation(
+    mode: 'per-track',
+  ): Array<SegmentationInitializationPerTrack<TSegmentUser>>;
+  initializeSegmentation(
+    mode?: 'combined' | 'per-track',
+  ):
+    | SegmentationInitialization<TSegmentUser>
+    | Array<SegmentationInitializationPerTrack<TSegmentUser>> {
     if (!this.onSegment) {
       Log.warn('MP4Box', 'No segmentation callback set!');
+    }
+    if (mode !== undefined && mode !== 'combined' && mode !== 'per-track') {
+      throw new Error(`Invalid segmentation mode: ${mode}`);
     }
     if (!this.isFragmentationInitialized) {
       this.isFragmentationInitialized = true;
       this.resetTables();
     }
 
-    // Create the moov that will hold all the tracks
-    const moov = new moovBox();
-    moov.addBox(this.moov.mvhd);
-
-    // Add the tracks we want to fragment
-    for (let i = 0; i < this.fragmentedTracks.length; i++) {
-      const trak = this.getTrackById(this.fragmentedTracks[i].id);
+    const tracksToInitialize: Array<{ id: number; user: TSegmentUser; trak: trakBox }> = [];
+    for (const fragmentedTrack of this.fragmentedTracks) {
+      const trak = this.getTrackById(fragmentedTrack.id);
       if (!trak) {
         Log.warn(
           'ISOFile',
-          `Track with id ${this.fragmentedTracks[i].id} not found, skipping fragmentation initialization`,
+          `Track with id ${fragmentedTrack.id} not found, skipping fragmentation initialization`,
         );
         continue;
       }
-      moov.addBox(trak);
+      tracksToInitialize.push({ id: fragmentedTrack.id, user: fragmentedTrack.user, trak });
+    }
+
+    const fragmentDuration = this.moov?.mvex?.mehd.fragment_duration;
+
+    if (mode === 'per-track') {
+      return tracksToInitialize.map(({ id, user, trak }) => {
+        const moov = new moovBox();
+        moov.addBox(this.moov.mvhd);
+        moov.addBox(trak);
+
+        return {
+          id,
+          user,
+          buffer: ISOFile.writeInitializationSegment(this.ftyp, moov, fragmentDuration),
+        };
+      });
+    }
+
+    // Create the moov that will hold all selected fragmented tracks
+    const moov = new moovBox();
+    moov.addBox(this.moov.mvhd);
+    for (const track of tracksToInitialize) {
+      moov.addBox(track.trak);
     }
 
     return {
-      tracks: moov.traks.map((trak, i) => ({
-        id: trak.tkhd.track_id,
-        user: this.fragmentedTracks[i].user,
-      })),
-      buffer: ISOFile.writeInitializationSegment(
-        this.ftyp,
-        moov,
-        this.moov?.mvex?.mehd.fragment_duration,
-      ),
+      tracks: tracksToInitialize.map(({ id, user }) => ({ id, user })),
+      buffer: ISOFile.writeInitializationSegment(this.ftyp, moov, fragmentDuration),
     };
   }
 

--- a/src/isofile.ts
+++ b/src/isofile.ts
@@ -93,6 +93,8 @@ import type {
   Item,
   Movie,
   Output,
+  SegmentationInitialization,
+  SegmentationInitializationPerTrack,
   Sample,
   SampleEntryFourCC,
   SubSample,
@@ -1272,42 +1274,65 @@ export class ISOFile<TSegmentUser = unknown, TSampleUser = unknown> {
   }
 
   /** @bundle isofile-write.js */
-  initializeSegmentation() {
+  initializeSegmentation(mode?: 'combined'): SegmentationInitialization<TSegmentUser>;
+  initializeSegmentation(
+    mode: 'per-track',
+  ): Array<SegmentationInitializationPerTrack<TSegmentUser>>;
+  initializeSegmentation(
+    mode?: 'combined' | 'per-track',
+  ):
+    | SegmentationInitialization<TSegmentUser>
+    | Array<SegmentationInitializationPerTrack<TSegmentUser>> {
     if (!this.onSegment) {
       Log.warn('MP4Box', 'No segmentation callback set!');
+    }
+    if (mode !== undefined && mode !== 'combined' && mode !== 'per-track') {
+      throw new Error(`Invalid segmentation mode: ${mode}`);
     }
     if (!this.isFragmentationInitialized) {
       this.isFragmentationInitialized = true;
       this.resetTables();
     }
 
-    // Create the moov that will hold all the tracks
-    const moov = new moovBox();
-    moov.addBox(this.moov.mvhd);
-
-    // Add the tracks we want to fragment
-    for (let i = 0; i < this.fragmentedTracks.length; i++) {
-      const trak = this.getTrackById(this.fragmentedTracks[i].id);
+    const tracksToInitialize: Array<{ id: number; user: TSegmentUser; trak: trakBox }> = [];
+    for (const fragmentedTrack of this.fragmentedTracks) {
+      const trak = this.getTrackById(fragmentedTrack.id);
       if (!trak) {
         Log.warn(
           'ISOFile',
-          `Track with id ${this.fragmentedTracks[i].id} not found, skipping fragmentation initialization`,
+          `Track with id ${fragmentedTrack.id} not found, skipping fragmentation initialization`,
         );
         continue;
       }
-      moov.addBox(trak);
+      tracksToInitialize.push({ id: fragmentedTrack.id, user: fragmentedTrack.user, trak });
+    }
+
+    const fragmentDuration = this.moov?.mvex?.mehd.fragment_duration;
+
+    if (mode === 'per-track') {
+      return tracksToInitialize.map(({ id, user, trak }) => {
+        const moov = new moovBox();
+        moov.addBox(this.moov.mvhd);
+        moov.addBox(trak);
+
+        return {
+          id,
+          user,
+          buffer: ISOFile.writeInitializationSegment(this.ftyp, moov, fragmentDuration),
+        };
+      });
+    }
+
+    // Create the moov that will hold all selected fragmented tracks
+    const moov = new moovBox();
+    moov.addBox(this.moov.mvhd);
+    for (const track of tracksToInitialize) {
+      moov.addBox(track.trak);
     }
 
     return {
-      tracks: moov.traks.map((trak, i) => ({
-        id: trak.tkhd.track_id,
-        user: this.fragmentedTracks[i].user,
-      })),
-      buffer: ISOFile.writeInitializationSegment(
-        this.ftyp,
-        moov,
-        this.moov?.mvex?.mehd.fragment_duration,
-      ),
+      tracks: tracksToInitialize.map(({ id, user }) => ({ id, user })),
+      buffer: ISOFile.writeInitializationSegment(this.ftyp, moov, fragmentDuration),
     };
   }
 

--- a/tests/segmentation.test.ts
+++ b/tests/segmentation.test.ts
@@ -31,7 +31,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -81,7 +81,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -128,7 +128,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -178,7 +178,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -290,5 +290,60 @@ describe('File Segmentation', () => {
     expect(fragTrack.state.lastSegmentSampleNumber).toBe(fragTrack.trak.nextSample);
     expect(fragTrack.state.accumulatedSize).toBe(0);
     expect(fragTrack.segmentStream).toBeUndefined();
+  });
+
+  it('with one init segment per fragmented track', async () => {
+    const { testFile } = getFilePath('isobmff', '01_simple.mp4');
+    const { mp4 } = await loadAndGetInfo(testFile, true, true);
+
+    mp4.setSegmentOptions(101, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+    mp4.setSegmentOptions(201, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+
+    const initSegments = mp4.initializeSegmentation('per-track');
+    expect(initSegments.length).toBe(2);
+
+    for (const initSegment of initSegments) {
+      const initMp4 = createFile();
+      initMp4.appendBuffer(MP4BoxBuffer.fromArrayBuffer(initSegment.buffer, 0));
+      initMp4.flush();
+
+      const info = initMp4.getInfo();
+      expect(info.tracks.length).toBe(1);
+      expect(info.tracks[0].id).toBe(initSegment.id);
+      expect(initMp4.moov.mvex.trexs.length).toBe(1);
+      expect(initMp4.moov.mvex.trexs[0].track_id).toBe(initSegment.id);
+    }
+  });
+
+  it('with explicit combined mode', async () => {
+    const { testFile } = getFilePath('isobmff', '01_simple.mp4');
+    const { mp4 } = await loadAndGetInfo(testFile, true, true);
+
+    mp4.setSegmentOptions(101, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+    mp4.setSegmentOptions(201, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+
+    const defaultInit = mp4.initializeSegmentation();
+    const combinedInit = mp4.initializeSegmentation('combined');
+
+    expect(combinedInit.tracks.map(track => track.id)).toEqual(
+      defaultInit.tracks.map(track => track.id),
+    );
+
+    const initMp4 = createFile();
+    initMp4.appendBuffer(MP4BoxBuffer.fromArrayBuffer(combinedInit.buffer, 0));
+    initMp4.flush();
+    expect(initMp4.getInfo().tracks.length).toBe(2);
   });
 });

--- a/tests/segmentation.test.ts
+++ b/tests/segmentation.test.ts
@@ -31,7 +31,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -81,7 +81,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -128,7 +128,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -178,7 +178,7 @@ describe('File Segmentation', () => {
     const init = mp4.initializeSegmentation();
 
     // Write the initialization segments to the output stream
-    out.insertBuffer(init.buffer);
+    out.insertBuffer(MP4BoxBuffer.fromArrayBuffer(init.buffer, offset));
     offset += init.buffer.byteLength;
     saveBufferToFile(init.buffer, task.id, true);
 
@@ -205,5 +205,60 @@ describe('File Segmentation', () => {
     expect(segmentCount).toBe(10);
     expect(newMP4.getBoxes('moof', false).length).toBe(10);
     expect(out.getAbsoluteEndPosition()).toBe(203_175);
+  });
+
+  it('with one init segment per fragmented track', async () => {
+    const { testFile } = getFilePath('isobmff', '01_simple.mp4');
+    const { mp4 } = await loadAndGetInfo(testFile, true, true);
+
+    mp4.setSegmentOptions(101, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+    mp4.setSegmentOptions(201, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+
+    const initSegments = mp4.initializeSegmentation('per-track');
+    expect(initSegments.length).toBe(2);
+
+    for (const initSegment of initSegments) {
+      const initMp4 = createFile();
+      initMp4.appendBuffer(MP4BoxBuffer.fromArrayBuffer(initSegment.buffer, 0));
+      initMp4.flush();
+
+      const info = initMp4.getInfo();
+      expect(info.tracks.length).toBe(1);
+      expect(info.tracks[0].id).toBe(initSegment.id);
+      expect(initMp4.moov.mvex.trexs.length).toBe(1);
+      expect(initMp4.moov.mvex.trexs[0].track_id).toBe(initSegment.id);
+    }
+  });
+
+  it('with explicit combined mode', async () => {
+    const { testFile } = getFilePath('isobmff', '01_simple.mp4');
+    const { mp4 } = await loadAndGetInfo(testFile, true, true);
+
+    mp4.setSegmentOptions(101, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+    mp4.setSegmentOptions(201, undefined, {
+      nbSamples: 50,
+      rapAlignement: false,
+    });
+
+    const defaultInit = mp4.initializeSegmentation();
+    const combinedInit = mp4.initializeSegmentation('combined');
+
+    expect(combinedInit.tracks.map(track => track.id)).toEqual(
+      defaultInit.tracks.map(track => track.id),
+    );
+
+    const initMp4 = createFile();
+    initMp4.appendBuffer(MP4BoxBuffer.fromArrayBuffer(combinedInit.buffer, 0));
+    initMp4.flush();
+    expect(initMp4.getInfo().tracks.length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

This PR adds a new segmentation initialization mode to support **one init segment per fragmented track** while preserving the existing combined-init behavior.

The main motivation is Media Source Extensions (MSE) integration: playback setups that require simultaneous multi-audio playback need one `MediaSource` (containing its `SourceBuffer`) per track, which in turn requires one init segment per track instead of a single combined init segment.

> [!NOTE]
> This behavior aligns with historical usage, per-track initialization used to be the default behavior.
> It stopped being the default in commit 77247e16 (`fix: segmenting will also multiplex the fragmented tracks`, Jul 8, 2025), first released in `v1.3.1`.

`initializeSegmentation` now supports:

- `initializeSegmentation()` / `initializeSegmentation('combined')` (default):
  returns a single init segment containing all selected fragmented tracks.
- `initializeSegmentation('per-track')`:
  returns one init segment per selected fragmented track.

## Documentation

Updated `README.md` segmentation docs (it seems to have been stale documenting the old behavior before 77247e16):

- documented `initializeSegmentation(mode)` with supported values (`'combined'` and `'per-track'`)
- updated examples to reflect current return shapes
- fixed the `setSegmentOptions` anchor link