### PR TITLE
Display uuid Value

### DIFF
--- a/.changeset/wise-experts-wonder.md
+++ b/.changeset/wise-experts-wonder.md
@@ -1,0 +1,5 @@
+---
+'mp4box': minor
+---
+
+The uuid boxes now display the extended_type, even if the box is already registered

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -149,6 +149,7 @@ export function parseOneBox(
       } else {
         if (uuid in BoxRegistry.uuid) {
           box = new BoxRegistry.uuid[uuid](size);
+          box.uuid = uuid;
         } else {
           Log.warn('BoxParser', `Unknown UUID box type: '${uuid}'`);
           box = new Box(size);


### PR DESCRIPTION
Previously, the GUI would only display the uuid value for unregistered boxes. However, it's still useful to see this value, even if MP4Box,.js recognizes the box.

<img width="451" height="148" alt="image" src="https://github.com/user-attachments/assets/35d08bbe-0ff9-4a92-b315-3146577027bf" />
