### PR TITLE
feat: add Dolby TrueHD SampleEntry and ConfigurationBox

### DIFF
--- a/entries/all-boxes.ts
+++ b/entries/all-boxes.ts
@@ -27,6 +27,7 @@ export * from '#/boxes/dfLa';
 export * from '#/boxes/dimm';
 export * from '#/boxes/dmax';
 export * from '#/boxes/dmed';
+export * from '#/boxes/dmlp';
 export * from '#/boxes/dOps';
 export * from '#/boxes/dref';
 export * from '#/boxes/drep';

--- a/src/boxes/dmlp.ts
+++ b/src/boxes/dmlp.ts
@@ -1,0 +1,26 @@
+import { Box } from '#/box';
+import { Log } from '#/log';
+import type { MultiBufferStream } from '#/buffer';
+
+export class dmlpBox extends Box {
+  static override readonly fourcc = 'dmlp' as const;
+  box_name = 'MLPSpecificBox' as const;
+
+  format_info: number;
+  peak_data_rate: number;
+
+  parse(stream: MultiBufferStream) {
+    this.format_info = stream.readUint16();
+    const tmp_16 = stream.readUint16();
+    this.peak_data_rate = tmp_16 >> 1;
+    let reserved = tmp_16 & 0x1;
+    if (reserved !== 0) {
+      Log.error('BoxParser', 'dmlp reserved parsing problem', stream.isofile);
+      return;
+    }
+    reserved = stream.readUint32();
+    if (reserved !== 0) {
+      Log.error('BoxParser', 'dmlp reserved parsing problem', stream.isofile);
+    }
+  }
+}

--- a/src/boxes/sampleentries/sampleentry.ts
+++ b/src/boxes/sampleentries/sampleentry.ts
@@ -416,6 +416,11 @@ export class ec_3SampleEntry extends AudioSampleEntry {
   static override readonly fourcc = 'ec-3' as const;
 }
 
+export class mlpaSampleEntry extends AudioSampleEntry {
+  static override readonly fourcc = 'mlpa' as const;
+  box_name = 'MLPSampleEntry' as const;
+}
+
 export class OpusSampleEntry extends AudioSampleEntry {
   static override readonly fourcc = 'Opus' as const;
 }


### PR DESCRIPTION
As the PR subject says, this add supports for Dolby TrueHD specific sample entry and configuration box.

The only issue is that samplerate in MLPSampleEntry, despite being an extension of AudioSampleEntry, is defined as a 32bit unsigned value instead of a 16.16 fixed point value as in the main spec. The idea was to support sample rates higher than 48Khz, but clearly people at Dolby did not realize that the srat box exists for this same purpose, and came up with this hack.

I don't know how to make the aforementioned change.
https://github.com/gpac/mp4box.js/blob/992505793e5a4aa5d513ec85e0cd7939535674a7/src/boxes/sampleentries/base.ts#L257
This should somehow check that the class extending AudioSampleEntry is MLPSampleEntry and then parse samplerate in a different way, probably in a similar fashion to the existing isQT check. Do you know how this could be done?

And then
https://github.com/gpac/mp4box.js/blob/992505793e5a4aa5d513ec85e0cd7939535674a7/src/boxes/sampleentries/base.ts#L301
Should do the same for writing.